### PR TITLE
JsonExtensionData

### DIFF
--- a/BaseLinkerApi/Requests/Orders/GetInvoices.cs
+++ b/BaseLinkerApi/Requests/Orders/GetInvoices.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using BaseLinkerApi.Common;
 using BaseLinkerApi.Common.JsonConverters;
@@ -66,6 +67,11 @@ public class GetInvoices : IRequest<GetInvoices.Response>
 
             [JsonPropertyName("quantity")]
             public int Quantity { get; set; }
+            
+            /// <summary>
+            /// Additional not parsed data
+            /// </summary>
+            [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
         }
 
         public class Invoice
@@ -178,6 +184,11 @@ public class GetInvoices : IRequest<GetInvoices.Response>
 
             [JsonPropertyName("items")]
             public List<Item> Items { get; set; }
+            
+            /// <summary>
+            /// Additional not parsed data
+            /// </summary>
+            [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
         }
             
         [JsonPropertyName("invoices")]

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using BaseLinkerApi.Common;
 using BaseLinkerApi.Common.JsonConverters;
@@ -129,6 +130,11 @@ public class GetOrders : IRequest<GetOrders.Response>
         /// </summary>
         [JsonPropertyName("bundle_id")]
         public int BundleId { get; set; }
+        
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
     }
 
     public class Order
@@ -287,6 +293,11 @@ public class GetOrders : IRequest<GetOrders.Response>
 
         [JsonPropertyName("products")]
         public List<Product> Products { get; set; }
+        
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
     }
         
     public class Response : ResponseBase


### PR DESCRIPTION
Some responses from Baselinker API contains additional data not parsed by library.
Examples:
`GetOrders.Order` field `delivery_country_code`
`GetInvoices.Response.Item` field `sku`

It's very likely that in feature more fields in API will be added.

`[JsonExtensionData]` can be used to overcome this problems
