### PR TITLE
Add get_government_data parameter and government fields to GetInvoices

### DIFF
--- a/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
+++ b/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
@@ -10,7 +10,7 @@
 
         <PackageId>BaseLinker.Extensions.DependencyInjection</PackageId>
         <Description>BaseLinker.com API client library (dependency injection extensions)</Description>
-        <PackageVersion>0.5.2.2</PackageVersion>
+        <Version>0.5.2.3</Version>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/BaseLinkerApi</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
+++ b/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>default</LangVersion>
         <Nullable>enable</Nullable>
@@ -10,7 +10,7 @@
 
         <PackageId>BaseLinker.Extensions.DependencyInjection</PackageId>
         <Description>BaseLinker.com API client library (dependency injection extensions)</Description>
-        <PackageVersion>0.2.6</PackageVersion>
+        <PackageVersion>0.5.2.2</PackageVersion>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/BaseLinkerApi</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
@@ -19,8 +19,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BaseLinkerApi.Tests/BaseLinkerApi.Tests.csproj
+++ b/BaseLinkerApi.Tests/BaseLinkerApi.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.2">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/BaseLinkerApi/BaseLinkerApi.csproj
+++ b/BaseLinkerApi/BaseLinkerApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;netstandard2.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
         <Nullable>annotations</Nullable>
 
@@ -9,7 +9,7 @@
         
         <PackageId>BaseLinker</PackageId>
         <Description>Base.com API client library</Description>
-        <PackageVersion>0.5.2</PackageVersion>
+        <PackageVersion>0.5.2.2</PackageVersion>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/baselinker-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
@@ -18,9 +18,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Net.Http.Json" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-      <PackageReference Include="System.Text.Json" Version="7.0.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-      <PackageReference Include="System.Threading.RateLimiting" Version="7.0.0" />
+      <PackageReference Include="System.Threading.RateLimiting" Version="10.0.5" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="System.Net.Http.Json" Version="10.0.5" />
+      <PackageReference Include="System.Text.Json" Version="10.0.5" />
     </ItemGroup>
 
 </Project>

--- a/BaseLinkerApi/BaseLinkerApi.csproj
+++ b/BaseLinkerApi/BaseLinkerApi.csproj
@@ -9,7 +9,7 @@
         
         <PackageId>BaseLinker</PackageId>
         <Description>Base.com API client library</Description>
-        <PackageVersion>0.5.2.2</PackageVersion>
+        <Version>0.5.2.3</Version>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/baselinker-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/BaseLinkerApi/Requests/Orders/GetInvoices.cs
+++ b/BaseLinkerApi/Requests/Orders/GetInvoices.cs
@@ -44,10 +44,16 @@ public class GetInvoices : IRequest<GetInvoices.Response>
     public int? SeriesId { get; set; }
         
     /// <summary>
-    /// (optional, true by default) Download external invoices as well.
+    /// (optional) If set to 'false' then omits from the results invoices that already have an external invoice file uploaded by addOrderInvoiceFile method (useful for ERP integrations uploading invoice files to BaseLinker)
     /// </summary>
     [JsonPropertyName("get_external_invoices")]
     public bool? GetExternalInvoices { get; set; }
+        
+    /// <summary>
+    /// (optional) If set to 'true' then includes government data fields in the response: gov_id, gov_date, gov_status.
+    /// </summary>
+    [JsonPropertyName("get_government_data")]
+    public bool? GetGovernmentData { get; set; }
         
     public class Response : ResponseBase
     {
@@ -187,6 +193,25 @@ public class GetInvoices : IRequest<GetInvoices.Response>
 
             [JsonPropertyName("items")]
             public List<Item> Items { get; set; }
+
+            /// <summary>
+            /// Government invoice identifier (returned when get_government_data is true).
+            /// </summary>
+            [JsonPropertyName("gov_id")]
+            public string GovId { get; set; }
+
+            /// <summary>
+            /// Government invoice date in Unix time format (returned when get_government_data is true).
+            /// </summary>
+            [JsonPropertyName("gov_date")]
+            [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+            public DateTimeOffset? GovDate { get; set; }
+
+            /// <summary>
+            /// Government invoice status: 1 = Sent, 2 = Accepted, 3 = Rejected, 5 = Offline mode (returned when get_government_data is true).
+            /// </summary>
+            [JsonPropertyName("gov_status")]
+            public int? GovStatus { get; set; }
             
             /// <summary>
             /// Additional not parsed data

--- a/ExampleConsoleApp/ExampleConsoleApp.csproj
+++ b/ExampleConsoleApp/ExampleConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates the `GetInvoices` request and response model to support retrieving government invoice data from the API. The changes add an option to include government-related fields in the response and update the invoice model to handle these new fields.

Enhancements to government invoice data support:

* Added the `GetGovernmentData` property to the `GetInvoices` request, allowing clients to specify whether government data fields (`gov_id`, `gov_date`, `gov_status`) should be included in the response.
* Extended the `Invoice` class in the response to include new properties: `GovId`, `GovDate`, and `GovStatus`, which represent government invoice identifier, date (in Unix time), and status, respectively. These fields are only populated if `get_government_data` is true in the request.

Improvements to existing property documentation:

* Updated the XML documentation for the `GetExternalInvoices` property to clarify its behavior and use case, especially for ERP integrations.