### PR TITLE
API changelog updates since 2023-08-23, modernization, and 1.0.0 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
     name: Build, pack and publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '7.0.202'
+          dotnet-version: '10.0.x'
 
       - name: Publish on version change
         id: publish_nuget

--- a/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
+++ b/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
@@ -1,26 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>default</LangVersion>
+        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
 
         <AssemblyName>BaseLinker.Extensions.DependencyInjection</AssemblyName>
 
         <PackageId>BaseLinker.Extensions.DependencyInjection</PackageId>
         <Description>BaseLinker.com API client library (dependency injection extensions)</Description>
-        <PackageVersion>0.2.6</PackageVersion>
+        <PackageVersion>0.3.0</PackageVersion>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
-        <RepositoryUrl>https://github.com/bugproof/BaseLinkerApi</RepositoryUrl>
+        <RepositoryUrl>https://github.com/bugproof/baselinker-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageIconUrl>https://baselinker.com/assets/images/favicons/apple-icon-120x120.png</PackageIconUrl>
+        <PackageIconUrl>https://base.com/assets/images/favicons/base.com/apple-touch-icon-120x120.png</PackageIconUrl>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BaseLinkerApi.Tests/BaseLinkerApi.Tests.csproj
+++ b/BaseLinkerApi.Tests/BaseLinkerApi.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.2">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/BaseLinkerApi/BaseLinkerApi.csproj
+++ b/BaseLinkerApi/BaseLinkerApi.csproj
@@ -9,7 +9,7 @@
 
         <PackageId>BaseLinker</PackageId>
         <Description>Base.com API client library</Description>
-        <PackageVersion>0.6.0</PackageVersion>
+        <PackageVersion>1.0.0</PackageVersion>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/baselinker-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/BaseLinkerApi/BaseLinkerApi.csproj
+++ b/BaseLinkerApi/BaseLinkerApi.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
-        <LangVersion>default</LangVersion>
+        <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
         <Nullable>annotations</Nullable>
 
         <AssemblyName>BaseLinker</AssemblyName>
-        
+
         <PackageId>BaseLinker</PackageId>
         <Description>Base.com API client library</Description>
-        <PackageVersion>0.5.2</PackageVersion>
+        <PackageVersion>0.6.0</PackageVersion>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/baselinker-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
@@ -18,9 +18,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Net.Http.Json" Version="7.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-      <PackageReference Include="System.Text.Json" Version="7.0.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-      <PackageReference Include="System.Threading.RateLimiting" Version="7.0.0" />
+      <PackageReference Include="System.Net.Http.Json" Version="10.0.8" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+      <PackageReference Include="System.Text.Json" Version="10.0.8" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+      <PackageReference Include="System.Threading.RateLimiting" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/BaseLinkerApi/Requests/BaseConnect/AddConnectContractorCredit.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/AddConnectContractorCredit.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.BaseConnect;
+
+/// <summary>
+/// The method allows you to add a trade credit entry for chosen contractor in Base Connect.
+/// </summary>
+public class AddConnectContractorCredit : IRequest
+{
+    /// <summary>
+    /// Contractor ID
+    /// </summary>
+    [JsonPropertyName("contractor_id")]
+    public int ContractorId { get; set; }
+
+    /// <summary>
+    /// Trade credit amount
+    /// </summary>
+    [JsonPropertyName("amount")]
+    public double Amount { get; set; }
+
+    /// <summary>
+    /// Trade credit note
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+}

--- a/BaseLinkerApi/Requests/BaseConnect/AddConnectContractorCredit.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/AddConnectContractorCredit.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 
 namespace BaseLinkerApi.Requests.BaseConnect;
@@ -5,6 +6,7 @@ namespace BaseLinkerApi.Requests.BaseConnect;
 /// <summary>
 /// The method allows you to add a trade credit entry for chosen contractor in Base Connect.
 /// </summary>
+[Obsolete("Deprecated (changelog 2025-10-21). It will do nothing. Use SetConnectContractorCreditLimit instead.")]
 public class AddConnectContractorCredit : IRequest
 {
     /// <summary>

--- a/BaseLinkerApi/Requests/BaseConnect/AddConnectContractorCredit.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/AddConnectContractorCredit.cs
@@ -10,8 +10,8 @@ public class AddConnectContractorCredit : IRequest
     /// <summary>
     /// Contractor ID
     /// </summary>
-    [JsonPropertyName("contractor_id")]
-    public int ContractorId { get; set; }
+    [JsonPropertyName("connect_contractor_id")]
+    public int ConnectContractorId { get; set; }
 
     /// <summary>
     /// Trade credit amount

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectContractorCreditHistory.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectContractorCreditHistory.cs
@@ -14,19 +14,16 @@ public class GetConnectContractorCreditHistory : IRequest<GetConnectContractorCr
     /// <summary>
     /// Contractor ID
     /// </summary>
-    [JsonPropertyName("contractor_id")]
-    public int ContractorId { get; set; }
-
-    [JsonPropertyName("token_id")]
-    public int TokenId { get; set; }
+    [JsonPropertyName("connect_contractor_id")]
+    public int ConnectContractorId { get; set; }
 
     public class CreditEntry
     {
         /// <summary>
         /// Entry ID
         /// </summary>
-        [JsonPropertyName("id")]
-        public int Id { get; set; }
+        [JsonPropertyName("credit_entry_id")]
+        public int CreditEntryId { get; set; }
 
         /// <summary>
         /// Entry add date in unix timestamp format

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectContractorCreditHistory.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectContractorCreditHistory.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.BaseConnect;
+
+/// <summary>
+/// The method allows you to retrieve an information about chosen contractor trade credit history.
+/// </summary>
+public class GetConnectContractorCreditHistory : IRequest<GetConnectContractorCreditHistory.Response>
+{
+    /// <summary>
+    /// Contractor ID
+    /// </summary>
+    [JsonPropertyName("contractor_id")]
+    public int ContractorId { get; set; }
+
+    [JsonPropertyName("token_id")]
+    public int TokenId { get; set; }
+
+    public class CreditEntry
+    {
+        /// <summary>
+        /// Entry ID
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Entry add date in unix timestamp format
+        /// </summary>
+        [JsonPropertyName("date_add")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateAdd { get; set; }
+
+        /// <summary>
+        /// Entry description
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Entry currency
+        /// </summary>
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Entry type: charge / payment
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Entry amount
+        /// </summary>
+        [JsonPropertyName("amount")]
+        public double Amount { get; set; }
+
+        /// <summary>
+        /// Entry status: 0 - waiting, 1 - active
+        /// </summary>
+        [JsonPropertyName("is_accepted")]
+        public int IsAccepted { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("credit_data")]
+        public List<CreditEntry> CreditData { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrationContractors.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrationContractors.cs
@@ -9,16 +9,19 @@ namespace BaseLinkerApi.Requests.BaseConnect;
 /// </summary>
 public class GetConnectIntegrationContractors : IRequest<GetConnectIntegrationContractors.Response>
 {
-    [JsonPropertyName("token_id")]
-    public int TokenId { get; set; }
+    /// <summary>
+    /// Connect integration ID
+    /// </summary>
+    [JsonPropertyName("connect_integration_id")]
+    public int ConnectIntegrationId { get; set; }
 
     public class Contractor
     {
         /// <summary>
         /// Contractor ID
         /// </summary>
-        [JsonPropertyName("id")]
-        public int Id { get; set; }
+        [JsonPropertyName("connect_contractor_id")]
+        public int ConnectContractorId { get; set; }
 
         /// <summary>
         /// Contractor name

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrationContractors.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrationContractors.cs
@@ -30,16 +30,16 @@ public class GetConnectIntegrationContractors : IRequest<GetConnectIntegrationCo
         public string Name { get; set; }
 
         /// <summary>
-        /// Contractor credit summary data
+        /// Contractor credit summary data. Raw JSON passthrough (deserializes to a <see cref="System.Text.Json.JsonElement"/>).
         /// </summary>
         [JsonPropertyName("credit_data")]
-        public Dictionary<string, object> CreditData { get; set; }
+        public object CreditData { get; set; }
 
         /// <summary>
-        /// Contractor options
+        /// Contractor options. Raw JSON passthrough (deserializes to a <see cref="System.Text.Json.JsonElement"/>).
         /// </summary>
         [JsonPropertyName("settings")]
-        public Dictionary<string, object> Settings { get; set; }
+        public object Settings { get; set; }
     }
 
     public class Response : ResponseBase

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrationContractors.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrationContractors.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.BaseConnect;
+
+/// <summary>
+/// The method allows you to retrieve a list of contractors connected to the selected Base Connect integration.
+/// </summary>
+public class GetConnectIntegrationContractors : IRequest<GetConnectIntegrationContractors.Response>
+{
+    [JsonPropertyName("token_id")]
+    public int TokenId { get; set; }
+
+    public class Contractor
+    {
+        /// <summary>
+        /// Contractor ID
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Contractor name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Contractor credit summary data
+        /// </summary>
+        [JsonPropertyName("credit_data")]
+        public Dictionary<string, object> CreditData { get; set; }
+
+        /// <summary>
+        /// Contractor options
+        /// </summary>
+        [JsonPropertyName("settings")]
+        public Dictionary<string, object> Settings { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("contractors")]
+        public List<Contractor> Contractors { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrations.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrations.cs
@@ -24,10 +24,10 @@ public class GetConnectIntegrations : IRequest<GetConnectIntegrations.Response>
         public string Name { get; set; }
 
         /// <summary>
-        /// Integration options
+        /// Integration options. Raw JSON passthrough (deserializes to a <see cref="System.Text.Json.JsonElement"/>).
         /// </summary>
         [JsonPropertyName("settings")]
-        public Dictionary<string, object> Settings { get; set; }
+        public object Settings { get; set; }
     }
 
     public class Response : ResponseBase

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrations.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrations.cs
@@ -14,8 +14,8 @@ public class GetConnectIntegrations : IRequest<GetConnectIntegrations.Response>
         /// <summary>
         /// Connect integration ID
         /// </summary>
-        [JsonPropertyName("id")]
-        public int Id { get; set; }
+        [JsonPropertyName("connect_integration_id")]
+        public int ConnectIntegrationId { get; set; }
 
         /// <summary>
         /// Integration name

--- a/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrations.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/GetConnectIntegrations.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.BaseConnect;
+
+/// <summary>
+/// The method allows you to retrieve a list of all Base Connect integrations on this account.
+/// </summary>
+public class GetConnectIntegrations : IRequest<GetConnectIntegrations.Response>
+{
+    public class Integration
+    {
+        /// <summary>
+        /// Connect integration ID
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Integration name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Integration options
+        /// </summary>
+        [JsonPropertyName("settings")]
+        public Dictionary<string, object> Settings { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// List of Base Connect integrations divided into own integrations (created on this account)
+        /// and connected integrations (integrations to which this account has connected).
+        /// </summary>
+        [JsonPropertyName("integrations")]
+        public List<Integration> Integrations { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/BaseConnect/SetConnectContractorCreditLimit.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/SetConnectContractorCreditLimit.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.BaseConnect;
+
+/// <summary>
+/// The method allows you to set new trade credit limit for chosen contractor.
+/// </summary>
+public class SetConnectContractorCreditLimit : IRequest<SetConnectContractorCreditLimit.Response>
+{
+    /// <summary>
+    /// Contractor ID
+    /// </summary>
+    [JsonPropertyName("contractor_id")]
+    public int ContractorId { get; set; }
+
+    /// <summary>
+    /// New limit value
+    /// </summary>
+    [JsonPropertyName("new_limit")]
+    public double NewLimit { get; set; }
+
+    /// <summary>
+    /// Message shown in trade credit history
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// New trade credit limit value (formatted with currency)
+        /// </summary>
+        [JsonPropertyName("new_limit_set")]
+        public string NewLimitSet { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/BaseConnect/SetConnectContractorCreditLimit.cs
+++ b/BaseLinkerApi/Requests/BaseConnect/SetConnectContractorCreditLimit.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 using BaseLinkerApi.Common;
 
@@ -11,8 +12,15 @@ public class SetConnectContractorCreditLimit : IRequest<SetConnectContractorCred
     /// <summary>
     /// Contractor ID
     /// </summary>
+    [Obsolete("Deprecated (changelog 2026-02-16). Use ConnectContractorId instead.")]
     [JsonPropertyName("contractor_id")]
-    public int ContractorId { get; set; }
+    public int? ContractorId { get; set; }
+
+    /// <summary>
+    /// Contractor ID
+    /// </summary>
+    [JsonPropertyName("connect_contractor_id")]
+    public int ConnectContractorId { get; set; }
 
     /// <summary>
     /// New limit value

--- a/BaseLinkerApi/Requests/CourierShipments/GetOrderPackages.cs
+++ b/BaseLinkerApi/Requests/CourierShipments/GetOrderPackages.cs
@@ -40,6 +40,12 @@ public class GetOrderPackages : IRequest<GetOrderPackages.Response>
 
         [JsonPropertyName("tracking_status")]
         public string TrackingStatus { get; set; }
+
+        /// <summary>
+        /// Is shipment return
+        /// </summary>
+        [JsonPropertyName("is_return")]
+        public bool IsReturn { get; set; }
     }
         
     public class Response : ResponseBase

--- a/BaseLinkerApi/Requests/CourierShipments/GetPackageDetails.cs
+++ b/BaseLinkerApi/Requests/CourierShipments/GetPackageDetails.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.CourierShipments;
+
+/// <summary>
+/// This method allows to get detailed information about a package. If the package contains multiple subpackages,
+/// information about all of them is included in the response.
+/// </summary>
+public class GetPackageDetails : IRequest<GetPackageDetails.Response>
+{
+    /// <summary>
+    /// Shipment ID
+    /// </summary>
+    [JsonPropertyName("package_id")]
+    public int PackageId { get; set; }
+
+    public class PackageDetail
+    {
+        /// <summary>
+        /// Package weight
+        /// </summary>
+        [JsonPropertyName("weight")]
+        public double Weight { get; set; }
+
+        /// <summary>
+        /// Unit of package weight ("kg", "g", "lb", "oz", "")
+        /// </summary>
+        [JsonPropertyName("weight_unit")]
+        public string WeightUnit { get; set; }
+
+        /// <summary>
+        /// Package length
+        /// </summary>
+        [JsonPropertyName("length")]
+        public double Length { get; set; }
+
+        /// <summary>
+        /// Package width
+        /// </summary>
+        [JsonPropertyName("width")]
+        public double Width { get; set; }
+
+        /// <summary>
+        /// Package height
+        /// </summary>
+        [JsonPropertyName("height")]
+        public double Height { get; set; }
+
+        /// <summary>
+        /// Unit of package size ("cm", "in", "")
+        /// </summary>
+        [JsonPropertyName("size_unit")]
+        public string SizeUnit { get; set; }
+
+        /// <summary>
+        /// Size template identifier if used, otherwise empty
+        /// </summary>
+        [JsonPropertyName("size_template")]
+        public string SizeTemplate { get; set; }
+
+        /// <summary>
+        /// True if package dimensions are custom, false otherwise
+        /// </summary>
+        [JsonPropertyName("is_custom")]
+        public bool IsCustom { get; set; }
+
+        /// <summary>
+        /// Cash on delivery (COD) value
+        /// </summary>
+        [JsonPropertyName("cod_value")]
+        public double CodValue { get; set; }
+
+        /// <summary>
+        /// Currency of COD value
+        /// </summary>
+        [JsonPropertyName("cod_currency")]
+        public string CodCurrency { get; set; }
+
+        /// <summary>
+        /// Insurance value of the package
+        /// </summary>
+        [JsonPropertyName("insurance_value")]
+        public double InsuranceValue { get; set; }
+
+        /// <summary>
+        /// Currency of insurance value
+        /// </summary>
+        [JsonPropertyName("insurance_currency")]
+        public string InsuranceCurrency { get; set; }
+
+        /// <summary>
+        /// Shipping cost declared for the package
+        /// </summary>
+        [JsonPropertyName("cost_value")]
+        public double CostValue { get; set; }
+
+        /// <summary>
+        /// Currency of shipping cost
+        /// </summary>
+        [JsonPropertyName("cost_currency")]
+        public string CostCurrency { get; set; }
+
+        /// <summary>
+        /// Type of packaging used ("package", "dox", "pallet", "")
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Date of dispatch (unix time format)
+        /// </summary>
+        [JsonPropertyName("pickup_date")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset PickupDate { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("package_details")]
+        public List<PackageDetail> PackageDetails { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Crm/AddCrmClient.cs
+++ b/BaseLinkerApi/Requests/Crm/AddCrmClient.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Crm;
+
+/// <summary>
+/// The method allows you to add a new CRM client. Adding a client with the same crm_client_id again will update
+/// the previously saved client (only the provided fields will be changed).
+/// </summary>
+public class AddCrmClient : IRequest<AddCrmClient.Response>
+{
+    /// <summary>
+    /// CRM client ID. If provided and greater than 0, the existing client will be updated. If 0 or omitted, a new client will be created.
+    /// </summary>
+    [JsonPropertyName("crm_client_id")]
+    public int? CrmClientId { get; set; }
+
+    /// <summary>
+    /// CRM client status ID.
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int? StatusId { get; set; }
+
+    /// <summary>
+    /// Star type. Values from 0 to 5. 0 means no star.
+    /// </summary>
+    [JsonPropertyName("star")]
+    public int? Star { get; set; }
+
+    /// <summary>
+    /// Base Connect contractor ID associated with the client (the list can be retrieved with getConnectIntegrationContractors method).
+    /// </summary>
+    [JsonPropertyName("contractor_id")]
+    public int? ContractorId { get; set; }
+
+    /// <summary>
+    /// Client login name.
+    /// </summary>
+    [JsonPropertyName("login")]
+    public string Login { get; set; }
+
+    /// <summary>
+    /// Client phone number.
+    /// </summary>
+    [JsonPropertyName("phone")]
+    public string Phone { get; set; }
+
+    /// <summary>
+    /// Client email address.
+    /// </summary>
+    [JsonPropertyName("email")]
+    public string Email { get; set; }
+
+    /// <summary>
+    /// Client notes.
+    /// </summary>
+    [JsonPropertyName("notes")]
+    public string Notes { get; set; }
+
+    [JsonPropertyName("invoice_company")]
+    public string InvoiceCompany { get; set; }
+
+    [JsonPropertyName("invoice_fullname")]
+    public string InvoiceFullname { get; set; }
+
+    [JsonPropertyName("invoice_address")]
+    public string InvoiceAddress { get; set; }
+
+    [JsonPropertyName("invoice_postcode")]
+    public string InvoicePostcode { get; set; }
+
+    [JsonPropertyName("invoice_city")]
+    public string InvoiceCity { get; set; }
+
+    [JsonPropertyName("invoice_state")]
+    public string InvoiceState { get; set; }
+
+    /// <summary>
+    /// Invoice country code (ISO 3166-1 alpha-2).
+    /// </summary>
+    [JsonPropertyName("invoice_country_code")]
+    public string InvoiceCountryCode { get; set; }
+
+    /// <summary>
+    /// Invoice tax ID (NIP). Whitespace and dashes are automatically removed.
+    /// </summary>
+    [JsonPropertyName("invoice_tax_id")]
+    public string InvoiceTaxId { get; set; }
+
+    [JsonPropertyName("delivery_company")]
+    public string DeliveryCompany { get; set; }
+
+    [JsonPropertyName("delivery_fullname")]
+    public string DeliveryFullname { get; set; }
+
+    [JsonPropertyName("delivery_address")]
+    public string DeliveryAddress { get; set; }
+
+    [JsonPropertyName("delivery_postcode")]
+    public string DeliveryPostcode { get; set; }
+
+    [JsonPropertyName("delivery_city")]
+    public string DeliveryCity { get; set; }
+
+    [JsonPropertyName("delivery_state")]
+    public string DeliveryState { get; set; }
+
+    /// <summary>
+    /// Delivery country code (ISO 3166-1 alpha-2).
+    /// </summary>
+    [JsonPropertyName("delivery_country_code")]
+    public string DeliveryCountryCode { get; set; }
+
+    /// <summary>
+    /// A list containing CRM client custom extra fields, where the key is the extra field ID and value is an extra field content for given extra field.
+    /// </summary>
+    [JsonPropertyName("custom_extra_fields")]
+    public Dictionary<string, object> CustomExtraFields { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// ID of the created or updated CRM client.
+        /// </summary>
+        [JsonPropertyName("crm_client_id")]
+        public int CrmClientId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Crm/DeleteCrmClient.cs
+++ b/BaseLinkerApi/Requests/Crm/DeleteCrmClient.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.Crm;
+
+/// <summary>
+/// The method allows you to remove a CRM client. Orders previously associated with the deleted client are not affected.
+/// </summary>
+public class DeleteCrmClient : IRequest
+{
+    /// <summary>
+    /// ID of the CRM client to delete.
+    /// </summary>
+    [JsonPropertyName("crm_client_id")]
+    public int CrmClientId { get; set; }
+}

--- a/BaseLinkerApi/Requests/Crm/GetCrmClientData.cs
+++ b/BaseLinkerApi/Requests/Crm/GetCrmClientData.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Crm;
+
+/// <summary>
+/// The method allows you to retrieve detailed data of a specific CRM client, including notes.
+/// </summary>
+public class GetCrmClientData : IRequest<GetCrmClientData.Response>
+{
+    /// <summary>
+    /// ID of the CRM client to retrieve.
+    /// </summary>
+    [JsonPropertyName("crm_client_id")]
+    public int CrmClientId { get; set; }
+
+    /// <summary>
+    /// (optional, false by default) Download values of custom additional fields.
+    /// </summary>
+    [JsonPropertyName("include_custom_extra_fields")]
+    public bool? IncludeCustomExtraFields { get; set; }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("crm_client_id")]
+        public int CrmClientId { get; set; }
+
+        [JsonPropertyName("status_id")]
+        public int StatusId { get; set; }
+
+        /// <summary>
+        /// Star type. Values from 0 to 5. 0 means no star.
+        /// </summary>
+        [JsonPropertyName("star")]
+        public int Star { get; set; }
+
+        [JsonPropertyName("login")]
+        public string Login { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [JsonPropertyName("notes")]
+        public string Notes { get; set; }
+
+        /// <summary>
+        /// Base Connect contractor ID associated with the client (0 if none).
+        /// </summary>
+        [JsonPropertyName("contractor_id")]
+        public int ContractorId { get; set; }
+
+        [JsonPropertyName("invoice_company")]
+        public string InvoiceCompany { get; set; }
+
+        [JsonPropertyName("invoice_fullname")]
+        public string InvoiceFullname { get; set; }
+
+        [JsonPropertyName("invoice_address")]
+        public string InvoiceAddress { get; set; }
+
+        [JsonPropertyName("invoice_postcode")]
+        public string InvoicePostcode { get; set; }
+
+        [JsonPropertyName("invoice_city")]
+        public string InvoiceCity { get; set; }
+
+        [JsonPropertyName("invoice_state")]
+        public string InvoiceState { get; set; }
+
+        [JsonPropertyName("invoice_country_code")]
+        public string InvoiceCountryCode { get; set; }
+
+        [JsonPropertyName("invoice_tax_id")]
+        public string InvoiceTaxId { get; set; }
+
+        [JsonPropertyName("delivery_company")]
+        public string DeliveryCompany { get; set; }
+
+        [JsonPropertyName("delivery_fullname")]
+        public string DeliveryFullname { get; set; }
+
+        [JsonPropertyName("delivery_address")]
+        public string DeliveryAddress { get; set; }
+
+        [JsonPropertyName("delivery_postcode")]
+        public string DeliveryPostcode { get; set; }
+
+        [JsonPropertyName("delivery_city")]
+        public string DeliveryCity { get; set; }
+
+        [JsonPropertyName("delivery_state")]
+        public string DeliveryState { get; set; }
+
+        [JsonPropertyName("delivery_country_code")]
+        public string DeliveryCountryCode { get; set; }
+
+        /// <summary>
+        /// A list containing CRM client custom extra fields returned only if the input parameter include_custom_extra_fields is set to true.
+        /// </summary>
+        [JsonPropertyName("custom_extra_fields")]
+        public Dictionary<string, object> CustomExtraFields { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Crm/GetCrmClientStatusGroups.cs
+++ b/BaseLinkerApi/Requests/Crm/GetCrmClientStatusGroups.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Crm;
+
+/// <summary>
+/// The method allows you to retrieve the list of CRM client status groups.
+/// </summary>
+public class GetCrmClientStatusGroups : IRequest<GetCrmClientStatusGroups.Response>
+{
+    public class StatusGroup
+    {
+        /// <summary>
+        /// Status group ID.
+        /// </summary>
+        [JsonPropertyName("group_id")]
+        public int GroupId { get; set; }
+
+        /// <summary>
+        /// Status group name.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Whether this is the main (default) group (0 or 1).
+        /// </summary>
+        [JsonPropertyName("is_main_group")]
+        public int IsMainGroup { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("status_groups")]
+        public List<StatusGroup> StatusGroups { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Crm/GetCrmClientStatuses.cs
+++ b/BaseLinkerApi/Requests/Crm/GetCrmClientStatuses.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Crm;
+
+/// <summary>
+/// The method allows you to retrieve CRM client statuses created by the user in the order manager.
+/// </summary>
+public class GetCrmClientStatuses : IRequest<GetCrmClientStatuses.Response>
+{
+    public class Status
+    {
+        /// <summary>
+        /// Status ID.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Status name.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Status color (hex, e.g. #1C8752).
+        /// </summary>
+        [JsonPropertyName("color")]
+        public string Color { get; set; }
+
+        /// <summary>
+        /// Status group ID. The group details can be retrieved with getCrmClientStatusGroups method.
+        /// </summary>
+        [JsonPropertyName("group_id")]
+        public int GroupId { get; set; }
+
+        /// <summary>
+        /// Whether this is the primary (default) status (0 or 1).
+        /// </summary>
+        [JsonPropertyName("is_primary")]
+        public int IsPrimary { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("statuses")]
+        public List<Status> Statuses { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Crm/GetCrmClients.cs
+++ b/BaseLinkerApi/Requests/Crm/GetCrmClients.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Crm;
+
+/// <summary>
+/// The method allows you to retrieve a list of CRM clients. The client list can be limited using the filters described in the method parameters.
+/// A maximum of 100 clients are returned at a time. To retrieve full client details (including notes and custom extra fields), use the getCrmClientData method.
+/// </summary>
+public class GetCrmClients : IRequest<GetCrmClients.Response>
+{
+    /// <summary>
+    /// Results page number (100 results per page, numbered from 1).
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; set; }
+
+    /// <summary>
+    /// Filter by exact CRM client ID.
+    /// </summary>
+    [JsonPropertyName("filter_crm_client_id")]
+    public int? FilterCrmClientId { get; set; }
+
+    /// <summary>
+    /// Filter by email (partial match).
+    /// </summary>
+    [JsonPropertyName("filter_email")]
+    public string? FilterEmail { get; set; }
+
+    /// <summary>
+    /// Filter by phone (partial match).
+    /// </summary>
+    [JsonPropertyName("filter_phone")]
+    public string? FilterPhone { get; set; }
+
+    /// <summary>
+    /// Filter by login (partial match).
+    /// </summary>
+    [JsonPropertyName("filter_login")]
+    public string? FilterLogin { get; set; }
+
+    /// <summary>
+    /// Filter by invoice company name (partial match).
+    /// </summary>
+    [JsonPropertyName("filter_invoice_company")]
+    public string? FilterInvoiceCompany { get; set; }
+
+    /// <summary>
+    /// Filter by invoice tax ID (partial match).
+    /// </summary>
+    [JsonPropertyName("filter_invoice_tax_id")]
+    public string? FilterInvoiceTaxId { get; set; }
+
+    /// <summary>
+    /// Filter by invoice full name (partial match).
+    /// </summary>
+    [JsonPropertyName("filter_invoice_fullname")]
+    public string? FilterInvoiceFullname { get; set; }
+
+    /// <summary>
+    /// Filter by exact status ID.
+    /// </summary>
+    [JsonPropertyName("filter_status_id")]
+    public int? FilterStatusId { get; set; }
+
+    public class Client
+    {
+        [JsonPropertyName("crm_client_id")]
+        public int CrmClientId { get; set; }
+
+        [JsonPropertyName("status_id")]
+        public int StatusId { get; set; }
+
+        /// <summary>
+        /// Star type. Values from 0 to 5. 0 means no star.
+        /// </summary>
+        [JsonPropertyName("star")]
+        public int Star { get; set; }
+
+        [JsonPropertyName("login")]
+        public string Login { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Base Connect contractor ID associated with the client (0 if none).
+        /// </summary>
+        [JsonPropertyName("contractor_id")]
+        public int ContractorId { get; set; }
+
+        [JsonPropertyName("invoice_company")]
+        public string InvoiceCompany { get; set; }
+
+        [JsonPropertyName("invoice_fullname")]
+        public string InvoiceFullname { get; set; }
+
+        [JsonPropertyName("invoice_address")]
+        public string InvoiceAddress { get; set; }
+
+        [JsonPropertyName("invoice_postcode")]
+        public string InvoicePostcode { get; set; }
+
+        [JsonPropertyName("invoice_city")]
+        public string InvoiceCity { get; set; }
+
+        [JsonPropertyName("invoice_state")]
+        public string InvoiceState { get; set; }
+
+        [JsonPropertyName("invoice_country_code")]
+        public string InvoiceCountryCode { get; set; }
+
+        [JsonPropertyName("invoice_tax_id")]
+        public string InvoiceTaxId { get; set; }
+
+        [JsonPropertyName("delivery_company")]
+        public string DeliveryCompany { get; set; }
+
+        [JsonPropertyName("delivery_fullname")]
+        public string DeliveryFullname { get; set; }
+
+        [JsonPropertyName("delivery_address")]
+        public string DeliveryAddress { get; set; }
+
+        [JsonPropertyName("delivery_postcode")]
+        public string DeliveryPostcode { get; set; }
+
+        [JsonPropertyName("delivery_city")]
+        public string DeliveryCity { get; set; }
+
+        [JsonPropertyName("delivery_state")]
+        public string DeliveryState { get; set; }
+
+        [JsonPropertyName("delivery_country_code")]
+        public string DeliveryCountryCode { get; set; }
+
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("clients")]
+        public List<Client> Clients { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ExternalStorages/GetExternalStorageProductsData.cs
+++ b/BaseLinkerApi/Requests/ExternalStorages/GetExternalStorageProductsData.cs
@@ -29,21 +29,27 @@ public class GetExternalStorageProductsData : IRequest<GetExternalStorageProduct
         [JsonPropertyName("price")]
         public decimal Price { get; set; }
             
-        [JsonPropertyName("quantity")] 
+        [JsonPropertyName("quantity")]
         public int Quantity { get; set; }
-            
+
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
     }
         
     public class Product
     {
         [JsonPropertyName("product_id")]
         public string ProductId { get; set; }
-            
+
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
-            
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
+
         [JsonPropertyName("sku")]
         public string Sku { get; set; }
             

--- a/BaseLinkerApi/Requests/ExternalStorages/GetExternalStorageProductsList.cs
+++ b/BaseLinkerApi/Requests/ExternalStorages/GetExternalStorageProductsList.cs
@@ -26,7 +26,13 @@ public class GetExternalStorageProductsList : IRequest<GetExternalStorageProduct
         
     [JsonPropertyName("filter_ean")]
     public string? FilterEan { get; set; }
-        
+
+    /// <summary>
+    /// (optional) limiting results to a specific asin
+    /// </summary>
+    [JsonPropertyName("filter_asin")]
+    public string? FilterAsin { get; set; }
+
     [JsonPropertyName("filter_sku")]
     public string? FilterSku { get; set; }
         
@@ -58,6 +64,9 @@ public class GetExternalStorageProductsList : IRequest<GetExternalStorageProduct
 
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
 
         [JsonPropertyName("sku")]
         public string Sku { get; set; }

--- a/BaseLinkerApi/Requests/OrderReturns/AddOrderReturn.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/AddOrderReturn.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows adding a new order return to BaseLinker.
+/// </summary>
+public class AddOrderReturn : IRequest<AddOrderReturn.Response>
+{
+    public class Product
+    {
+        /// <summary>
+        /// Type of warehouse from which the product comes (available values: "db" - BaseLinker internal inventory, "shop" - the online store warehouse, "warehouse" - a connected wholesaler).
+        /// </summary>
+        [JsonPropertyName("storage")]
+        public string Storage { get; set; }
+
+        /// <summary>
+        /// The identifier of the warehouse from which the product comes. Value "0" for a product from the BaseLinker internal inventory.
+        /// </summary>
+        [JsonPropertyName("storage_id")]
+        public int StorageId { get; set; }
+
+        /// <summary>
+        /// Product identifier in BaseLinker or store warehouse. Blank if the product number is unknown.
+        /// </summary>
+        [JsonPropertyName("product_id")]
+        public string ProductId { get; set; }
+
+        /// <summary>
+        /// Product variant ID. Blank if the variant number is unknown.
+        /// </summary>
+        [JsonPropertyName("variant_id")]
+        public int VariantId { get; set; }
+
+        /// <summary>
+        /// Product name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Product sku
+        /// </summary>
+        [JsonPropertyName("sku")]
+        public string Sku { get; set; }
+
+        /// <summary>
+        /// Product ean
+        /// </summary>
+        [JsonPropertyName("ean")]
+        public string Ean { get; set; }
+
+        /// <summary>
+        /// Product location
+        /// </summary>
+        [JsonPropertyName("location")]
+        public string Location { get; set; }
+
+        /// <summary>
+        /// Product source warehouse identifier. Only applies to products from BaseLinker inventory.
+        /// </summary>
+        [JsonPropertyName("warehouse_id")]
+        public int WarehouseId { get; set; }
+
+        /// <summary>
+        /// Specific product attributes (e.g. "Color: blue")
+        /// </summary>
+        [JsonPropertyName("attributes")]
+        public string Attributes { get; set; }
+
+        /// <summary>
+        /// Single item gross price
+        /// </summary>
+        [JsonPropertyName("price_brutto")]
+        public double PriceBrutto { get; set; }
+
+        /// <summary>
+        /// VAT tax rate e.g. "23"
+        /// </summary>
+        [JsonPropertyName("tax_rate")]
+        public double TaxRate { get; set; }
+
+        /// <summary>
+        /// Quantity of pieces
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// Single item weight
+        /// </summary>
+        [JsonPropertyName("weight")]
+        public double Weight { get; set; }
+
+        /// <summary>
+        /// Identifier of return item status.
+        /// </summary>
+        [JsonPropertyName("status_id")]
+        public int StatusId { get; set; }
+
+        /// <summary>
+        /// Identifier of return reason.
+        /// </summary>
+        [JsonPropertyName("return_reason_id")]
+        public int ReturnReasonId { get; set; }
+    }
+
+    /// <summary>
+    /// (optional) Order ID in BaseLinker panel
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int? OrderId { get; set; }
+
+    /// <summary>
+    /// Order return status (the list available to retrieve with getOrderReturnStatusList).
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int StatusId { get; set; }
+
+    /// <summary>
+    /// (optional) Identifier of custom order source defined in BaseLinker panel. If not provided, default order return source is assigned.
+    /// </summary>
+    [JsonPropertyName("custom_source_id")]
+    public int? CustomSourceId { get; set; }
+
+    /// <summary>
+    /// (optional) Reference number from external source.
+    /// </summary>
+    [JsonPropertyName("reference_number")]
+    public string? ReferenceNumber { get; set; }
+
+    /// <summary>
+    /// Date of order return creation (in unix time format)
+    /// </summary>
+    [JsonPropertyName("date_add")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset DateAdd { get; set; }
+
+    /// <summary>
+    /// 3-letter currency symbol (e.g. EUR, PLN)
+    /// </summary>
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// Information whether the order return is already refunded. The value "1" automatically marks order return as refunded.
+    /// </summary>
+    [JsonPropertyName("refunded")]
+    public bool? Refunded { get; set; }
+
+    /// <summary>
+    /// Seller comments
+    /// </summary>
+    [JsonPropertyName("admin_comments")]
+    public string AdminComments { get; set; }
+
+    /// <summary>
+    /// Buyer e-mail address
+    /// </summary>
+    [JsonPropertyName("email")]
+    public string Email { get; set; }
+
+    /// <summary>
+    /// Buyer phone number
+    /// </summary>
+    [JsonPropertyName("phone")]
+    public string Phone { get; set; }
+
+    /// <summary>
+    /// Marketplace user login
+    /// </summary>
+    [JsonPropertyName("user_login")]
+    public string UserLogin { get; set; }
+
+    /// <summary>
+    /// Gross delivery price
+    /// </summary>
+    [JsonPropertyName("delivery_price")]
+    public double? DeliveryPrice { get; set; }
+
+    [JsonPropertyName("delivery_fullname")]
+    public string DeliveryFullname { get; set; }
+
+    [JsonPropertyName("delivery_company")]
+    public string DeliveryCompany { get; set; }
+
+    [JsonPropertyName("delivery_address")]
+    public string DeliveryAddress { get; set; }
+
+    [JsonPropertyName("delivery_postcode")]
+    public string DeliveryPostcode { get; set; }
+
+    [JsonPropertyName("delivery_city")]
+    public string DeliveryCity { get; set; }
+
+    [JsonPropertyName("delivery_state")]
+    public string DeliveryState { get; set; }
+
+    [JsonPropertyName("delivery_country_code")]
+    public string DeliveryCountryCode { get; set; }
+
+    /// <summary>
+    /// Value of the "additional field 1"
+    /// </summary>
+    [JsonPropertyName("extra_field_1")]
+    public string ExtraField1 { get; set; }
+
+    /// <summary>
+    /// Value of the "additional field 2"
+    /// </summary>
+    [JsonPropertyName("extra_field_2")]
+    public string ExtraField2 { get; set; }
+
+    /// <summary>
+    /// A list containing order return custom extra fields, where the key is the extra field ID and value is an extra field content for given extra field.
+    /// The list of extra fields can be retrieved with getOrderReturnExtraFields method.
+    /// </summary>
+    [JsonPropertyName("custom_extra_fields")]
+    public Dictionary<string, object> CustomExtraFields { get; set; }
+
+    /// <summary>
+    /// Return product array.
+    /// </summary>
+    [JsonPropertyName("products")]
+    public List<Product> Products { get; set; }
+
+    /// <summary>
+    /// Bank account number to issue a refund
+    /// </summary>
+    [JsonPropertyName("refund_account_number")]
+    public string RefundAccountNumber { get; set; }
+
+    /// <summary>
+    /// IBAN of the bank account
+    /// </summary>
+    [JsonPropertyName("refund_iban")]
+    public string RefundIban { get; set; }
+
+    /// <summary>
+    /// SWIFT of the bank account
+    /// </summary>
+    [JsonPropertyName("refund_swift")]
+    public string RefundSwift { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Identifier of added return.
+        /// </summary>
+        [JsonPropertyName("return_id")]
+        public int ReturnId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/AddOrderReturn.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/AddOrderReturn.cs
@@ -14,6 +14,12 @@ public class AddOrderReturn : IRequest<AddOrderReturn.Response>
     public class Product
     {
         /// <summary>
+        /// (optional) ID of connected order item from BaseLinker order manager.
+        /// </summary>
+        [JsonPropertyName("order_product_id")]
+        public int? OrderProductId { get; set; }
+
+        /// <summary>
         /// Type of warehouse from which the product comes (available values: "db" - BaseLinker internal inventory, "shop" - the online store warehouse, "warehouse" - a connected wholesaler).
         /// </summary>
         [JsonPropertyName("storage")]

--- a/BaseLinkerApi/Requests/OrderReturns/AddOrderReturnProduct.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/AddOrderReturnProduct.cs
@@ -1,0 +1,127 @@
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// Add new product to existing order return.
+/// </summary>
+public class AddOrderReturnProduct : IRequest<AddOrderReturnProduct.Response>
+{
+    /// <summary>
+    /// Order return identifier. Field required. Other fields are optional.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// Type of product source storage (available values: "db" - BaseLinker internal inventory, "shop" - online shop storage, "warehouse" - the connected wholesaler)
+    /// </summary>
+    [JsonPropertyName("storage")]
+    public string Storage { get; set; }
+
+    /// <summary>
+    /// The identifier of the storage (inventory/shop/warehouse) from which the product comes.
+    /// </summary>
+    [JsonPropertyName("storage_id")]
+    public string StorageId { get; set; }
+
+    /// <summary>
+    /// Product identifier in BaseLinker or shop storage. Blank if the product number is not known.
+    /// </summary>
+    [JsonPropertyName("product_id")]
+    public string ProductId { get; set; }
+
+    /// <summary>
+    /// Product variant ID. Blank if the variant number is unknown.
+    /// </summary>
+    [JsonPropertyName("variant_id")]
+    public string VariantId { get; set; }
+
+    /// <summary>
+    /// Listing ID number (if the order comes from ebay/allegro)
+    /// </summary>
+    [JsonPropertyName("auction_id")]
+    public string AuctionId { get; set; }
+
+    /// <summary>
+    /// Product name
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Product SKU number
+    /// </summary>
+    [JsonPropertyName("sku")]
+    public string Sku { get; set; }
+
+    /// <summary>
+    /// Product EAN number
+    /// </summary>
+    [JsonPropertyName("ean")]
+    public string Ean { get; set; }
+
+    /// <summary>
+    /// Product location
+    /// </summary>
+    [JsonPropertyName("location")]
+    public string Location { get; set; }
+
+    /// <summary>
+    /// Product source warehouse identifier. Only applies to products from BaseLinker inventory.
+    /// </summary>
+    [JsonPropertyName("warehouse_id")]
+    public int? WarehouseId { get; set; }
+
+    /// <summary>
+    /// The detailed product attributes, e.g. "Colour: blue" (Variant name)
+    /// </summary>
+    [JsonPropertyName("attributes")]
+    public string Attributes { get; set; }
+
+    /// <summary>
+    /// Single item gross price
+    /// </summary>
+    [JsonPropertyName("price_brutto")]
+    public double? PriceBrutto { get; set; }
+
+    /// <summary>
+    /// VAT tax rate e.g. "23"
+    /// </summary>
+    [JsonPropertyName("tax_rate")]
+    public double? TaxRate { get; set; }
+
+    /// <summary>
+    /// Number of pieces
+    /// </summary>
+    [JsonPropertyName("quantity")]
+    public int? Quantity { get; set; }
+
+    /// <summary>
+    /// Single piece weight
+    /// </summary>
+    [JsonPropertyName("weight")]
+    public decimal? Weight { get; set; }
+
+    /// <summary>
+    /// Identifier of return item status. The list can be retrieved with getOrderReturnProductStatuses method.
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int? StatusId { get; set; }
+
+    /// <summary>
+    /// Identifier of return reason. The list can be retrieved with getOrderReturnReasonsList method.
+    /// </summary>
+    [JsonPropertyName("return_reason_id")]
+    public int? ReturnReasonId { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Identifier of the item added to the return.
+        /// </summary>
+        [JsonPropertyName("order_return_product_id")]
+        public int OrderReturnProductId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/AddOrderReturnProduct.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/AddOrderReturnProduct.cs
@@ -15,6 +15,12 @@ public class AddOrderReturnProduct : IRequest<AddOrderReturnProduct.Response>
     public int ReturnId { get; set; }
 
     /// <summary>
+    /// (optional) ID of connected order item from BaseLinker order manager.
+    /// </summary>
+    [JsonPropertyName("order_product_id")]
+    public int? OrderProductId { get; set; }
+
+    /// <summary>
     /// Type of product source storage (available values: "db" - BaseLinker internal inventory, "shop" - online shop storage, "warehouse" - the connected wholesaler)
     /// </summary>
     [JsonPropertyName("storage")]

--- a/BaseLinkerApi/Requests/OrderReturns/DeleteOrderReturnProduct.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/DeleteOrderReturnProduct.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to remove a specific product from the return.
+/// </summary>
+public class DeleteOrderReturnProduct : IRequest
+{
+    /// <summary>
+    /// Order return ID.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// Order return item ID.
+    /// </summary>
+    [JsonPropertyName("order_return_product_id")]
+    public int OrderReturnProductId { get; set; }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnExtraFields.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnExtraFields.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method returns extra fields defined for order returns. Values of those fields can be set with method setOrderReturnFields.
+/// To retrieve values of those fields set parameter include_custom_extra_fields in method getOrderReturns.
+/// </summary>
+public class GetOrderReturnExtraFields : IRequest<GetOrderReturnExtraFields.Response>
+{
+    public class ExtraField
+    {
+        /// <summary>
+        /// ID of the extra field
+        /// </summary>
+        [JsonPropertyName("extra_field_id")]
+        public int ExtraFieldId { get; set; }
+
+        /// <summary>
+        /// Field name.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Editor type. The following values are available: text, number, select, checkbox, radio, date, file.
+        /// </summary>
+        [JsonPropertyName("editor_type")]
+        public string EditorType { get; set; }
+
+        /// <summary>
+        /// (optional) An array of values available for a given additional field. Applicable to select, checkbox and radio editors.
+        /// </summary>
+        [JsonPropertyName("options")]
+        public List<string> Options { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("extra_fields")]
+        public List<ExtraField> ExtraFields { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnJournalList.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnJournalList.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to download a list of return events from the last 3 days.
+/// </summary>
+public class GetOrderReturnJournalList : IRequest<GetOrderReturnJournalList.Response>
+{
+    /// <summary>
+    /// Log ID number from which the logs are to be retrieved
+    /// </summary>
+    [JsonPropertyName("last_log_id")]
+    public int LastLogId { get; set; }
+
+    /// <summary>
+    /// Event ID List
+    /// </summary>
+    [JsonPropertyName("logs_types")]
+    public List<int> LogsTypes { get; set; }
+
+    /// <summary>
+    /// Return ID number
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int? ReturnId { get; set; }
+
+    public class Log
+    {
+        /// <summary>
+        /// Event ID
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Return identifier
+        /// </summary>
+        [JsonPropertyName("return_id")]
+        public int ReturnId { get; set; }
+
+        /// <summary>
+        /// Event type: 1 - Return creation, 2 - Return accepted, 3 - Return completed, 4 - Return canceled,
+        /// 5 - Return refunded, 6 - Editing return delivery data, 7 - Adding a product to a return,
+        /// 8 - Editing a product in the return, 9 - Removing a product from the return, 10 - Editing return data,
+        /// 11 - Return status change, 12 - Return item status change
+        /// </summary>
+        [JsonPropertyName("log_type")]
+        public int LogType { get; set; }
+
+        /// <summary>
+        /// Additional information, depending on the event type: 9 - Deleted product ID, 14 - Created return parcel ID, 15 - Deleted return parcel ID
+        /// </summary>
+        [JsonPropertyName("object_id")]
+        public int ObjectId { get; set; }
+
+        /// <summary>
+        /// Event date
+        /// </summary>
+        [JsonPropertyName("date")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset Date { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("logs")]
+        public List<Log> Logs { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnPaymentsHistory.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnPaymentsHistory.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to retrieve payment history for a selected order return, including an external payment identifier from the payment gateway.
+/// One order can have multiple payment history entries, caused by surcharges, order value changes, manual payment editing.
+/// </summary>
+public class GetOrderReturnPaymentsHistory : IRequest<GetOrderReturnPaymentsHistory.Response>
+{
+    /// <summary>
+    /// Order return identifier.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// (optional, false by default) Download full payment history, including order value change entries, manual order payment edits.
+    /// False by default - only returns entries containing an external payment identifier (most commonly used).
+    /// </summary>
+    [JsonPropertyName("show_full_history")]
+    public bool? ShowFullHistory { get; set; }
+
+    public class Payment
+    {
+        /// <summary>
+        /// Total amount paid before the given change
+        /// </summary>
+        [JsonPropertyName("paid_before")]
+        public double PaidBefore { get; set; }
+
+        /// <summary>
+        /// Total amount paid after the change
+        /// </summary>
+        [JsonPropertyName("paid_after")]
+        public double PaidAfter { get; set; }
+
+        /// <summary>
+        /// Total order price
+        /// </summary>
+        [JsonPropertyName("total_price")]
+        public double TotalPrice { get; set; }
+
+        /// <summary>
+        /// The currency
+        /// </summary>
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// External payment identifier
+        /// </summary>
+        [JsonPropertyName("external_payment_id")]
+        public string ExternalPaymentId { get; set; }
+
+        /// <summary>
+        /// Date of change record (unix time format)
+        /// </summary>
+        [JsonPropertyName("date")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset Date { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("payments")]
+        public List<Payment> Payments { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnProductStatuses.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnProductStatuses.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method returns a list of order return item statuses. Values of those fields can be set with method setOrderReturnFields.
+/// </summary>
+public class GetOrderReturnProductStatuses : IRequest<GetOrderReturnProductStatuses.Response>
+{
+    public class Status
+    {
+        /// <summary>
+        /// ID of the order return item status
+        /// </summary>
+        [JsonPropertyName("status_id")]
+        public int StatusId { get; set; }
+
+        /// <summary>
+        /// Order return item status name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("order_return_product_statuses")]
+        public List<Status> OrderReturnProductStatuses { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnReasonsList.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnReasonsList.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method returns a list of order return reasons. Values of those fields can be set with method setOrderReturnFields.
+/// </summary>
+public class GetOrderReturnReasonsList : IRequest<GetOrderReturnReasonsList.Response>
+{
+    public class ReturnReason
+    {
+        /// <summary>
+        /// ID of the order return reason
+        /// </summary>
+        [JsonPropertyName("return_reason_id")]
+        public int ReturnReasonId { get; set; }
+
+        /// <summary>
+        /// Order return reason name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("return_reasons")]
+        public List<ReturnReason> ReturnReasons { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnStatusList.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturnStatusList.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to download order return statuses created by the customer in the BaseLinker order manager.
+/// </summary>
+public class GetOrderReturnStatusList : IRequest<GetOrderReturnStatusList.Response>
+{
+    public class Status
+    {
+        /// <summary>
+        /// Status identifier
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Status name (basic)
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Long status name (displayed to the customer on the order page)
+        /// </summary>
+        [JsonPropertyName("name_for_customer")]
+        public string NameForCustomer { get; set; }
+
+        /// <summary>
+        /// Status color in hex
+        /// </summary>
+        [JsonPropertyName("color")]
+        public string Color { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("statuses")]
+        public List<Status> Statuses { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
@@ -64,6 +64,12 @@ public class GetOrderReturns : IRequest<GetOrderReturns.Response>
     [JsonPropertyName("include_custom_extra_fields")]
     public bool? IncludeCustomExtraFields { get; set; }
 
+    /// <summary>
+    /// (optional, false by default) Base Connect and contractor data. If set to true, the response will contain additional "connect_data" field.
+    /// </summary>
+    [JsonPropertyName("include_connect_data")]
+    public bool? IncludeConnectData { get; set; }
+
     public class Product
     {
         [JsonPropertyName("order_product_id")]
@@ -219,6 +225,12 @@ public class GetOrderReturns : IRequest<GetOrderReturns.Response>
 
         [JsonPropertyName("delivery_package_nr")]
         public string DeliveryPackageNr { get; set; }
+
+        /// <summary>
+        /// Data from Base Connect linked to the order return. Returned only when include_connect_data is set to true.
+        /// </summary>
+        [JsonPropertyName("connect_data")]
+        public object ConnectData { get; set; }
 
         [JsonPropertyName("products")]
         public List<Product> Products { get; set; }

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
@@ -124,6 +124,12 @@ public class GetOrderReturns : IRequest<GetOrderReturns.Response>
         public int ReturnReasonId { get; set; }
 
         /// <summary>
+        /// Customer comment about return reason
+        /// </summary>
+        [JsonPropertyName("return_reason_comment")]
+        public string ReturnReasonComment { get; set; }
+
+        /// <summary>
         /// Additional not parsed data
         /// </summary>
         [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to download order returns from a specific date from the BaseLinker return manager.
+/// The return list can be limited using the filters described in the method parameters. A maximum of 100 order returns are returned at a time.
+/// </summary>
+public class GetOrderReturns : IRequest<GetOrderReturns.Response>
+{
+    /// <summary>
+    /// (optional) Identifier of an order the return was created from.
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int? OrderId { get; set; }
+
+    /// <summary>
+    /// (optional) Order return identifier. Completing this field will download information about only one specific order return.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int? ReturnId { get; set; }
+
+    /// <summary>
+    /// (optional) The return creation date from which order returns are to be collected. Format unix time stamp.
+    /// </summary>
+    [JsonPropertyName("date_from")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? DateFrom { get; set; }
+
+    /// <summary>
+    /// (optional) The order return ID number from which subsequent order returns are to be collected.
+    /// </summary>
+    [JsonPropertyName("id_from")]
+    public int? IdFrom { get; set; }
+
+    /// <summary>
+    /// (optional) The status identifier from which order returns are to be collected. Leave blank to download order returns from all statuses.
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int? StatusId { get; set; }
+
+    /// <summary>
+    /// (optional) Filtering of order return lists by order return source, for instance "ebay", "amazon".
+    /// The list of order return sources can be retrieved with getOrderSources method.
+    /// </summary>
+    [JsonPropertyName("filter_order_return_source")]
+    public string? FilterOrderReturnSource { get; set; }
+
+    /// <summary>
+    /// (optional) Filtering of order return lists by order return source identifier.
+    /// Filtering by order return source identifier requires "filter_order_return_source" to be set prior.
+    /// </summary>
+    [JsonPropertyName("filter_order_return_source_id")]
+    public int? FilterOrderReturnSourceId { get; set; }
+
+    /// <summary>
+    /// (optional, false by default) Download values of custom additional fields.
+    /// </summary>
+    [JsonPropertyName("include_custom_extra_fields")]
+    public bool? IncludeCustomExtraFields { get; set; }
+
+    public class Product
+    {
+        [JsonPropertyName("order_product_id")]
+        public int OrderProductId { get; set; }
+
+        [JsonPropertyName("storage")]
+        public string Storage { get; set; }
+
+        [JsonPropertyName("storage_id")]
+        public int StorageId { get; set; }
+
+        [JsonPropertyName("product_id")]
+        public string ProductId { get; set; }
+
+        [JsonPropertyName("variant_id")]
+        public int VariantId { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("sku")]
+        public string Sku { get; set; }
+
+        [JsonPropertyName("ean")]
+        public string Ean { get; set; }
+
+        [JsonPropertyName("location")]
+        public string Location { get; set; }
+
+        [JsonPropertyName("warehouse_id")]
+        public int WarehouseId { get; set; }
+
+        [JsonPropertyName("attributes")]
+        public string Attributes { get; set; }
+
+        [JsonPropertyName("price_brutto")]
+        public double PriceBrutto { get; set; }
+
+        [JsonPropertyName("tax_rate")]
+        public double TaxRate { get; set; }
+
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        [JsonPropertyName("weight")]
+        public double Weight { get; set; }
+
+        [JsonPropertyName("status_id")]
+        public int StatusId { get; set; }
+
+        [JsonPropertyName("return_reason_id")]
+        public int ReturnReasonId { get; set; }
+
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
+    }
+
+    public class Return
+    {
+        [JsonPropertyName("return_id")]
+        public int ReturnId { get; set; }
+
+        [JsonPropertyName("order_id")]
+        public int OrderId { get; set; }
+
+        [JsonPropertyName("shop_order_id")]
+        public int ShopOrderId { get; set; }
+
+        [JsonPropertyName("external_order_id")]
+        public string ExternalOrderId { get; set; }
+
+        [JsonPropertyName("reference_number")]
+        public string ReferenceNumber { get; set; }
+
+        [JsonPropertyName("order_return_source")]
+        public string OrderReturnSource { get; set; }
+
+        [JsonPropertyName("order_return_source_id")]
+        public int OrderReturnSourceId { get; set; }
+
+        [JsonPropertyName("status_id")]
+        public int StatusId { get; set; }
+
+        [JsonPropertyName("date_add")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateAdd { get; set; }
+
+        [JsonPropertyName("date_in_status")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateInStatus { get; set; }
+
+        [JsonPropertyName("user_login")]
+        public string UserLogin { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Information whether the order return is already refunded.
+        /// </summary>
+        [JsonPropertyName("refunded")]
+        public string Refunded { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("delivery_price")]
+        public double DeliveryPrice { get; set; }
+
+        [JsonPropertyName("delivery_fullname")]
+        public string DeliveryFullname { get; set; }
+
+        [JsonPropertyName("delivery_company")]
+        public string DeliveryCompany { get; set; }
+
+        [JsonPropertyName("delivery_address")]
+        public string DeliveryAddress { get; set; }
+
+        [JsonPropertyName("delivery_postcode")]
+        public string DeliveryPostcode { get; set; }
+
+        [JsonPropertyName("delivery_city")]
+        public string DeliveryCity { get; set; }
+
+        [JsonPropertyName("delivery_state")]
+        public string DeliveryState { get; set; }
+
+        [JsonPropertyName("delivery_country")]
+        public string DeliveryCountry { get; set; }
+
+        [JsonPropertyName("delivery_country_code")]
+        public string DeliveryCountryCode { get; set; }
+
+        [JsonPropertyName("extra_field_1")]
+        public string ExtraField1 { get; set; }
+
+        [JsonPropertyName("extra_field_2")]
+        public string ExtraField2 { get; set; }
+
+        [JsonPropertyName("custom_extra_fields")]
+        public Dictionary<string, object> CustomExtraFields { get; set; }
+
+        [JsonPropertyName("admin_comments")]
+        public string AdminComments { get; set; }
+
+        [JsonPropertyName("delivery_package_module")]
+        public string DeliveryPackageModule { get; set; }
+
+        [JsonPropertyName("delivery_package_nr")]
+        public string DeliveryPackageNr { get; set; }
+
+        [JsonPropertyName("products")]
+        public List<Product> Products { get; set; }
+
+        [JsonPropertyName("order_return_account_number")]
+        public string OrderReturnAccountNumber { get; set; }
+
+        [JsonPropertyName("order_return_iban")]
+        public string OrderReturnIban { get; set; }
+
+        [JsonPropertyName("order_return_swift")]
+        public string OrderReturnSwift { get; set; }
+
+        /// <summary>
+        /// Fulfillment status ID: 0 - active, 5 - accepted, 1 - done, 2 - canceled
+        /// </summary>
+        [JsonPropertyName("fulfillment_status")]
+        public int FulfillmentStatus { get; set; }
+
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("returns")]
+        public List<Return> Returns { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/GetOrderReturns.cs
@@ -181,6 +181,12 @@ public class GetOrderReturns : IRequest<GetOrderReturns.Response>
         [JsonPropertyName("refunded")]
         public string Refunded { get; set; }
 
+        /// <summary>
+        /// The actual amount refunded to the buyer.
+        /// </summary>
+        [JsonPropertyName("refund_done")]
+        public double RefundDone { get; set; }
+
         [JsonPropertyName("email")]
         public string Email { get; set; }
 

--- a/BaseLinkerApi/Requests/OrderReturns/RunOrderReturnMacroTrigger.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/RunOrderReturnMacroTrigger.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to run personal trigger for order returns automatic actions.
+/// </summary>
+public class RunOrderReturnMacroTrigger : IRequest
+{
+    /// <summary>
+    /// Order return identifier from BaseLinker order manager.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// Identifier of personal trigger from orders automatic actions.
+    /// </summary>
+    [JsonPropertyName("trigger_id")]
+    public int TriggerId { get; set; }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnFields.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnFields.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to edit selected fields of a specific order return.
+/// Only the fields that you want to edit should be given, other fields can be omitted in the request.
+/// </summary>
+public class SetOrderReturnFields : IRequest
+{
+    /// <summary>
+    /// Order return identifier. Field required. Other fields are optional.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// Seller comments
+    /// </summary>
+    [JsonPropertyName("admin_comments")]
+    public string? AdminComments { get; set; }
+
+    /// <summary>
+    /// Buyer e-mail address
+    /// </summary>
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Buyer phone number
+    /// </summary>
+    [JsonPropertyName("phone")]
+    public string? Phone { get; set; }
+
+    /// <summary>
+    /// Buyer login
+    /// </summary>
+    [JsonPropertyName("user_login")]
+    public string? UserLogin { get; set; }
+
+    /// <summary>
+    /// Gross delivery price
+    /// </summary>
+    [JsonPropertyName("delivery_price")]
+    public double? DeliveryPrice { get; set; }
+
+    [JsonPropertyName("delivery_fullname")]
+    public string? DeliveryFullname { get; set; }
+
+    [JsonPropertyName("delivery_company")]
+    public string? DeliveryCompany { get; set; }
+
+    [JsonPropertyName("delivery_address")]
+    public string? DeliveryAddress { get; set; }
+
+    [JsonPropertyName("delivery_postcode")]
+    public string? DeliveryPostcode { get; set; }
+
+    [JsonPropertyName("delivery_city")]
+    public string? DeliveryCity { get; set; }
+
+    [JsonPropertyName("delivery_state")]
+    public string? DeliveryState { get; set; }
+
+    [JsonPropertyName("delivery_country_code")]
+    public string? DeliveryCountryCode { get; set; }
+
+    /// <summary>
+    /// Value of the "extra field 1".
+    /// </summary>
+    [JsonPropertyName("extra_field_1")]
+    public string? ExtraField1 { get; set; }
+
+    /// <summary>
+    /// Value of the "extra field 2".
+    /// </summary>
+    [JsonPropertyName("extra_field_2")]
+    public string? ExtraField2 { get; set; }
+
+    /// <summary>
+    /// A list containing order return custom extra fields, where the key is the extra field ID and value is an extra field content for given extra field.
+    /// The list of extra fields can be retrieved with getOrderReturnExtraFields method.
+    /// </summary>
+    [JsonPropertyName("custom_extra_fields")]
+    public Dictionary<string, object>? CustomExtraFields { get; set; }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnProductFields.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnProductFields.cs
@@ -1,0 +1,100 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to edit the data of selected items (e.g. prices, quantities etc.) of a specific order return.
+/// Only the fields that you want to edit should be given, the remaining fields can be omitted in the request.
+/// </summary>
+public class SetOrderReturnProductFields : IRequest
+{
+    /// <summary>
+    /// Order return identifier from the BaseLinker order manager. Field required.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// Order return item ID from BaseLinker order manager. Field required.
+    /// </summary>
+    [JsonPropertyName("order_return_product_id")]
+    public int OrderReturnProductId { get; set; }
+
+    /// <summary>
+    /// Type of product source storage (available values: "db" - BaseLinker internal inventory, "shop" - online shop storage, "warehouse" - the connected wholesaler)
+    /// </summary>
+    [JsonPropertyName("storage")]
+    public string? Storage { get; set; }
+
+    /// <summary>
+    /// The identifier of the storage (inventory/shop/warehouse) from which the product comes.
+    /// </summary>
+    [JsonPropertyName("storage_id")]
+    public string? StorageId { get; set; }
+
+    [JsonPropertyName("product_id")]
+    public string? ProductId { get; set; }
+
+    [JsonPropertyName("variant_id")]
+    public string? VariantId { get; set; }
+
+    [JsonPropertyName("auction_id")]
+    public string? AuctionId { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("sku")]
+    public string? Sku { get; set; }
+
+    [JsonPropertyName("ean")]
+    public string? Ean { get; set; }
+
+    [JsonPropertyName("location")]
+    public string? Location { get; set; }
+
+    [JsonPropertyName("warehouse_id")]
+    public int? WarehouseId { get; set; }
+
+    /// <summary>
+    /// The detailed product attributes, e.g. "Colour: blue" (Variant name)
+    /// </summary>
+    [JsonPropertyName("attributes")]
+    public string? Attributes { get; set; }
+
+    /// <summary>
+    /// Single item gross price.
+    /// </summary>
+    [JsonPropertyName("price_brutto")]
+    public double? PriceBrutto { get; set; }
+
+    /// <summary>
+    /// VAT tax rate e.g. "23"
+    /// </summary>
+    [JsonPropertyName("tax_rate")]
+    public double? TaxRate { get; set; }
+
+    /// <summary>
+    /// Number of pieces
+    /// </summary>
+    [JsonPropertyName("quantity")]
+    public int? Quantity { get; set; }
+
+    /// <summary>
+    /// Single piece weight
+    /// </summary>
+    [JsonPropertyName("weight")]
+    public decimal? Weight { get; set; }
+
+    /// <summary>
+    /// Identifier of product return status. The list can be retrieved with getOrderReturnProductStatuses method.
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int? StatusId { get; set; }
+
+    /// <summary>
+    /// Identifier of return reason. The list can be retrieved with getOrderReturnReasonsList method.
+    /// </summary>
+    [JsonPropertyName("return_reason_id")]
+    public int? ReturnReasonId { get; set; }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnRefund.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnRefund.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to mark an order return as refunded. Note this method doesn't issue an actual money refund.
+/// </summary>
+public class SetOrderReturnRefund : IRequest
+{
+    /// <summary>
+    /// Order return ID.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// The amount of the refund. The value changes the current refund in the order return (not added to the previous value).
+    /// If the amount matches the order value, the order will be marked as refund.
+    /// </summary>
+    [JsonPropertyName("order_refund_done")]
+    public double OrderRefundDone { get; set; }
+
+    /// <summary>
+    /// Refund date (unixtime format).
+    /// </summary>
+    [JsonPropertyName("refund_date")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset RefundDate { get; set; }
+
+    /// <summary>
+    /// Refund commentary.
+    /// </summary>
+    [JsonPropertyName("refund_comment")]
+    public string RefundComment { get; set; }
+
+    /// <summary>
+    /// (optional) External refund identifier
+    /// </summary>
+    [JsonPropertyName("external_refund_id")]
+    public string? ExternalRefundId { get; set; }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnStatus.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnStatus.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to change order return status.
+/// </summary>
+public class SetOrderReturnStatus : IRequest
+{
+    /// <summary>
+    /// Order return ID number.
+    /// </summary>
+    [JsonPropertyName("return_id")]
+    public int ReturnId { get; set; }
+
+    /// <summary>
+    /// Status ID number. The status list can be retrieved using getOrderReturnStatusList.
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int StatusId { get; set; }
+}

--- a/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnStatuses.cs
+++ b/BaseLinkerApi/Requests/OrderReturns/SetOrderReturnStatuses.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.OrderReturns;
+
+/// <summary>
+/// The method allows you to batch set order return statuses.
+/// </summary>
+public class SetOrderReturnStatuses : IRequest
+{
+    /// <summary>
+    /// Array of Order return ID numbers
+    /// </summary>
+    [JsonPropertyName("return_ids")]
+    public List<int> ReturnIds { get; set; }
+
+    /// <summary>
+    /// Order return status ID number. The status list can be retrieved using getOrderReturnStatusList.
+    /// </summary>
+    [JsonPropertyName("status_id")]
+    public int StatusId { get; set; }
+}

--- a/BaseLinkerApi/Requests/Orders/AddOrder.cs
+++ b/BaseLinkerApi/Requests/Orders/AddOrder.cs
@@ -32,7 +32,10 @@ public class AddOrder : IRequest<AddOrder.Response>
 
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
-            
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
+
         [JsonPropertyName("location")]
         public string Location { get; set; }
             

--- a/BaseLinkerApi/Requests/Orders/AddOrderBySplit.cs
+++ b/BaseLinkerApi/Requests/Orders/AddOrderBySplit.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Orders;
+
+/// <summary>
+/// Creates a new order by splitting selected products from an existing order.
+/// The new order inherits all fields and information from the original one.
+/// </summary>
+public class AddOrderBySplit : IRequest<AddOrderBySplit.Response>
+{
+    /// <summary>
+    /// ID of the order to split
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    public class ItemToSplit
+    {
+        /// <summary>
+        /// ID of the product in the original order (from getOrders method)
+        /// </summary>
+        [JsonPropertyName("order_product_id")]
+        public int OrderProductId { get; set; }
+
+        /// <summary>
+        /// Quantity to be moved (must be less than or equal to the original quantity)
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+    }
+
+    /// <summary>
+    /// A list of products to move to the new order.
+    /// </summary>
+    [JsonPropertyName("items_to_split")]
+    public List<ItemToSplit> ItemsToSplit { get; set; }
+
+    /// <summary>
+    /// (optional) Delivery cost (net or gross, depending on order) to transfer to the new order.
+    /// This amount will be deducted from the original order and assigned to the new one. Must not exceed the current delivery price.
+    /// </summary>
+    [JsonPropertyName("delivery_cost_to_split")]
+    public double? DeliveryCostToSplit { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// ID of the newly created order
+        /// </summary>
+        [JsonPropertyName("new_order_id")]
+        public int NewOrderId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Orders/AddOrderDuplicate.cs
+++ b/BaseLinkerApi/Requests/Orders/AddOrderDuplicate.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Orders;
+
+/// <summary>
+/// The method allows you to add a new order to the BaseLinker order manager by duplicating an existing order.
+/// The new order will have the same data as the original order, but with a different ID.
+/// </summary>
+public class AddOrderDuplicate : IRequest<AddOrderDuplicate.Response>
+{
+    /// <summary>
+    /// ID of the order to duplicate
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// ID of added order.
+        /// </summary>
+        [JsonPropertyName("order_id")]
+        public int OrderId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Orders/GetInvoices.cs
+++ b/BaseLinkerApi/Requests/Orders/GetInvoices.cs
@@ -44,11 +44,17 @@ public class GetInvoices : IRequest<GetInvoices.Response>
     public int? SeriesId { get; set; }
         
     /// <summary>
-    /// (optional, true by default) Download external invoices as well.
+    /// (optional) If set to 'false' then omits from the results invoices that already have an external invoice file uploaded by addOrderInvoiceFile method (useful for ERP integrations uploading invoice files to BaseLinker)
     /// </summary>
     [JsonPropertyName("get_external_invoices")]
     public bool? GetExternalInvoices { get; set; }
-        
+
+    /// <summary>
+    /// (optional) If set to 'true' then includes government data fields in the response: gov_id, gov_date, gov_status.
+    /// </summary>
+    [JsonPropertyName("get_government_data")]
+    public bool? GetGovernmentData { get; set; }
+
     public class Response : ResponseBase
     {
         public class Item
@@ -187,7 +193,26 @@ public class GetInvoices : IRequest<GetInvoices.Response>
 
             [JsonPropertyName("items")]
             public List<Item> Items { get; set; }
-            
+
+            /// <summary>
+            /// Government invoice identifier (returned when get_government_data is true).
+            /// </summary>
+            [JsonPropertyName("gov_id")]
+            public string GovId { get; set; }
+
+            /// <summary>
+            /// Government invoice date in Unix time format (returned when get_government_data is true).
+            /// </summary>
+            [JsonPropertyName("gov_date")]
+            [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+            public DateTimeOffset? GovDate { get; set; }
+
+            /// <summary>
+            /// Government invoice status: 1 = Sent, 2 = Accepted, 3 = Rejected, 5 = Offline mode (returned when get_government_data is true).
+            /// </summary>
+            [JsonPropertyName("gov_status")]
+            public int? GovStatus { get; set; }
+
             /// <summary>
             /// Additional not parsed data
             /// </summary>

--- a/BaseLinkerApi/Requests/Orders/GetJournalList.cs
+++ b/BaseLinkerApi/Requests/Orders/GetJournalList.cs
@@ -27,6 +27,15 @@ public class GetJournalList : IRequest<GetJournalList.Response>
             [JsonPropertyName("log_id")]
             public int LogId { get; set; }
 
+            /// <summary>
+            /// Event type: 1 - Order creation, 2 - DOF download (order confirmation), 3 - Payment of the order,
+            /// 4 - Removal of order/invoice/receipt, 5 - Merging the orders, 6 - Splitting the order,
+            /// 7 - Issuing an invoice, 8 - Issuing a receipt, 9 - Package creation, 10 - Deleting a package,
+            /// 11 - Editing delivery data, 12 - Adding a product to an order, 13 - Editing the product in the order,
+            /// 14 - Removing the product from the order, 15 - Adding a buyer to a blacklist, 16 - Editing order data,
+            /// 17 - Copying an order, 18 - Order status change, 19 - Invoice deletion, 20 - Receipt deletion,
+            /// 21 - Editing invoice data
+            /// </summary>
             [JsonPropertyName("log_type")]
             public int LogType { get; set; }
 

--- a/BaseLinkerApi/Requests/Orders/GetJournalList.cs
+++ b/BaseLinkerApi/Requests/Orders/GetJournalList.cs
@@ -24,7 +24,10 @@ public class GetJournalList : IRequest<GetJournalList.Response>
     {
         public class Log
         {
-            [JsonPropertyName("log_id")]
+            /// <summary>
+            /// Event ID. API field: "id".
+            /// </summary>
+            [JsonPropertyName("id")]
             public int LogId { get; set; }
 
             /// <summary>

--- a/BaseLinkerApi/Requests/Orders/GetJournalList.cs
+++ b/BaseLinkerApi/Requests/Orders/GetJournalList.cs
@@ -34,7 +34,7 @@ public class GetJournalList : IRequest<GetJournalList.Response>
             /// 11 - Editing delivery data, 12 - Adding a product to an order, 13 - Editing the product in the order,
             /// 14 - Removing the product from the order, 15 - Adding a buyer to a blacklist, 16 - Editing order data,
             /// 17 - Copying an order, 18 - Order status change, 19 - Invoice deletion, 20 - Receipt deletion,
-            /// 21 - Editing invoice data
+            /// 21 - Editing invoice data, 22 - Package status change
             /// </summary>
             [JsonPropertyName("log_type")]
             public int LogType { get; set; }
@@ -42,6 +42,12 @@ public class GetJournalList : IRequest<GetJournalList.Response>
             [JsonPropertyName("order_id")]
             public int OrderId { get; set; }
 
+            /// <summary>
+            /// Additional information, depending on the event type, e.g.: 5 - ID of the merged order,
+            /// 6 - ID of the new order created by the order separation, 7 - Invoice ID, 9 - Created parcel ID,
+            /// 10 - Deleted parcel ID, 14 - Deleted product ID, 17 - Created order ID, 18 - Order status ID,
+            /// 22 - Parcel ID with changed status
+            /// </summary>
             [JsonPropertyName("object_id")]
             public int ObjectId { get; set; }
 

--- a/BaseLinkerApi/Requests/Orders/GetJournalList.cs
+++ b/BaseLinkerApi/Requests/Orders/GetJournalList.cs
@@ -25,10 +25,10 @@ public class GetJournalList : IRequest<GetJournalList.Response>
         public class Log
         {
             /// <summary>
-            /// Event ID. API field: "id".
+            /// Event ID
             /// </summary>
             [JsonPropertyName("id")]
-            public int LogId { get; set; }
+            public int Id { get; set; }
 
             /// <summary>
             /// Event type: 1 - Order creation, 2 - DOF download (order confirmation), 3 - Payment of the order,

--- a/BaseLinkerApi/Requests/Orders/GetOrderPickPackHistory.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrderPickPackHistory.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.Orders;
+
+/// <summary>
+/// The method allows you to retrieve pick pack history for a selected order.
+/// </summary>
+public class GetOrderPickPackHistory : IRequest<GetOrderPickPackHistory.Response>
+{
+    /// <summary>
+    /// Order Identifier from BaseLinker order manager
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    /// <summary>
+    /// (optional) Event type you want to retrieve. Available values:
+    /// 1 - Reservation of an order for products collecting, 2 - Picking products started, 3 - Picking products cancelled,
+    /// 4 - Products picking status changed: in progress, 5 - Products picking status changed: finished,
+    /// 6 - Products picking status changed: error, 7 - Reservation of an order for products packing,
+    /// 8 - Packing products started, 9 - Packing products cancelled, 10 - Products packing status changed: in progress,
+    /// 11 - Products packing status changed: finished, 12 - Products packing status changed: error,
+    /// 13 - Products photo initialized, 14 - Products photo taken, 15 - Products photo deleted,
+    /// 16 - Error when trying to save products photo, 17 - Error when trying to save product image: image size too large,
+    /// 18 - Package photo received via Base Connect
+    /// </summary>
+    [JsonPropertyName("action_type")]
+    public int? ActionType { get; set; }
+
+    public class Response : ResponseBase
+    {
+        public class HistoryEntry
+        {
+            /// <summary>
+            /// Action type. See <see cref="GetOrderPickPackHistory.ActionType"/> for the list of available values.
+            /// </summary>
+            [JsonPropertyName("action_type")]
+            public int ActionType { get; set; }
+
+            /// <summary>
+            /// Name of the profile performing the change
+            /// </summary>
+            [JsonPropertyName("profile_id")]
+            public string ProfileId { get; set; }
+
+            /// <summary>
+            /// Id of the packing station
+            /// </summary>
+            [JsonPropertyName("station_id")]
+            public int StationId { get; set; }
+
+            /// <summary>
+            /// Id of cart assigned to order
+            /// </summary>
+            [JsonPropertyName("cart_id")]
+            public int CartId { get; set; }
+
+            /// <summary>
+            /// Date of history entry (unix time format)
+            /// </summary>
+            [JsonPropertyName("entry_date")]
+            [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+            public DateTimeOffset EntryDate { get; set; }
+        }
+
+        [JsonPropertyName("history")]
+        public List<HistoryEntry> History { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Orders/GetOrderPrintoutTemplates.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrderPrintoutTemplates.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Orders;
+
+/// <summary>
+/// Returns a list of all configured printout templates available for orders.
+/// The output includes technical identifiers used when executing a printout.
+/// </summary>
+public class GetOrderPrintoutTemplates : IRequest<GetOrderPrintoutTemplates.Response>
+{
+    public class Printout
+    {
+        /// <summary>
+        /// Unique identifier of the printout template
+        /// </summary>
+        [JsonPropertyName("printout_id")]
+        public int PrintoutId { get; set; }
+
+        /// <summary>
+        /// Name of the printout template
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Output format (e.g. PDF, HTML, XLS)
+        /// </summary>
+        [JsonPropertyName("file_format")]
+        public string FileFormat { get; set; }
+
+        /// <summary>
+        /// Language of the template
+        /// </summary>
+        [JsonPropertyName("language")]
+        public string Language { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("printouts")]
+        public List<Printout> Printouts { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Orders/GetOrderTransactionData.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrderTransactionData.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.Orders;
+
+/// <summary>
+/// The method allows you to retrieve transaction details for a selected order.
+/// </summary>
+public class GetOrderTransactionData : IRequest<GetOrderTransactionData.Response>
+{
+    /// <summary>
+    /// Order Identifier from BaseLinker order manager
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    /// <summary>
+    /// (optional, false by default) Whether to include detailed tax breakdown with order_lines structure.
+    /// </summary>
+    [JsonPropertyName("include_complex_taxes")]
+    public bool? IncludeComplexTaxes { get; set; }
+
+    /// <summary>
+    /// (optional, true by default) Whether to include legacy Amazon fulfillment data for backward compatibility.
+    /// </summary>
+    [JsonPropertyName("include_amazon_data")]
+    public bool? IncludeAmazonData { get; set; }
+
+    public class OrderItem
+    {
+        /// <summary>
+        /// Product SKU or identifier
+        /// </summary>
+        [JsonPropertyName("itemId")]
+        public string ItemId { get; set; }
+
+        /// <summary>
+        /// Additional identifier ("p" + sku)
+        /// </summary>
+        [JsonPropertyName("outerItemId")]
+        public string OuterItemId { get; set; }
+
+        /// <summary>
+        /// Shipping costs and taxes for this specific product
+        /// </summary>
+        [JsonPropertyName("shipping")]
+        public object Shipping { get; set; }
+
+        /// <summary>
+        /// Array of tax objects applied to the product
+        /// </summary>
+        [JsonPropertyName("taxes")]
+        public List<object> Taxes { get; set; }
+
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Order currency code
+        /// </summary>
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// [Only for Amazon] An array of information about the Amazon fulfillment shipments found.
+        /// </summary>
+        [JsonPropertyName("fulfillment_shipments")]
+        public List<AmazonFulfillmentShipment> FulfillmentShipments { get; set; }
+
+        /// <summary>
+        /// [Only for Amazon Vendor] Amazon fulfillment center identifier. (Requires providing "include_amazon_data" parameter)
+        /// </summary>
+        [JsonPropertyName("fulfillment_center_id")]
+        public string FulfillmentCenterId { get; set; }
+
+        /// <summary>
+        /// Ship date from (unix time format)
+        /// </summary>
+        [JsonPropertyName("ship_date_from")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset ShipDateFrom { get; set; }
+
+        /// <summary>
+        /// Ship date to (unix time format)
+        /// </summary>
+        [JsonPropertyName("ship_date_to")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset ShipDateTo { get; set; }
+
+        /// <summary>
+        /// Delivery date from (unix time format)
+        /// </summary>
+        [JsonPropertyName("delivery_date_from")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DeliveryDateFrom { get; set; }
+
+        /// <summary>
+        /// Delivery date to (unix time format)
+        /// </summary>
+        [JsonPropertyName("delivery_date_to")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DeliveryDateTo { get; set; }
+
+        /// <summary>
+        /// Transaction identifier from marketplace
+        /// </summary>
+        [JsonPropertyName("marketplace_transaction_id")]
+        public string MarketplaceTransactionId { get; set; }
+
+        /// <summary>
+        /// Marketplace account identifier
+        /// </summary>
+        [JsonPropertyName("account_id")]
+        public int AccountId { get; set; }
+
+        /// <summary>
+        /// Transaction date (unix timestamp)
+        /// </summary>
+        [JsonPropertyName("transaction_date")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset TransactionDate { get; set; }
+
+        /// <summary>
+        /// (only when include_complex_taxes=true) Detailed tax breakdown per product.
+        /// </summary>
+        [JsonPropertyName("order_items")]
+        public List<OrderItem> OrderItems { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/Orders/GetOrderTransactionDetails.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrderTransactionDetails.cs
@@ -24,6 +24,7 @@ public class AmazonFulfillmentShipment
 /// <summary>
 /// The method allows you to retrieve transaction details for a selected order (it now works only for orders from Amazon)
 /// </summary>
+[Obsolete("Replaced by GetOrderTransactionData (changelog 2024-06-05).")]
 public class GetOrderTransactionDetails : IRequest<GetOrderTransactionDetails.Response>
 {
     /// <summary>

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -303,6 +303,12 @@ public class GetOrders : IRequest<GetOrders.Response>
         [JsonPropertyName("pack_status")]
         public int PackStatus { get; set; }
 
+        /// <summary>
+        /// The commissions that the marketplace charges for an order. Returned only when commission data is requested (with_commission flag enabled).
+        /// </summary>
+        [JsonPropertyName("commissions")]
+        public object Commissions { get; set; }
+
         [JsonPropertyName("products")]
         public List<Product> Products { get; set; }
         

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -115,7 +115,10 @@ public class GetOrders : IRequest<GetOrders.Response>
 
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
-            
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
+
         [JsonPropertyName("location")]
         public string Location { get; set; }
             

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -86,7 +86,14 @@ public class GetOrders : IRequest<GetOrders.Response>
     /// </summary>
     [JsonPropertyName("filter_order_source_id")]
     public int? FilterOrderSourceId { get; set; }
-    
+
+    /// <summary>
+    /// (optional) External order identifier. Allows filtering orders by the original order ID assigned by the marketplace or online store
+    /// (e.g. Allegro transaction number, Amazon order number). This is the same value as the "external_order_id" field in the response.
+    /// </summary>
+    [JsonPropertyName("filter_external_order_id")]
+    public string? FilterExternalOrderId { get; set; }
+
     public class Product
     {
         [JsonPropertyName("storage")]

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -319,10 +319,16 @@ public class GetOrders : IRequest<GetOrders.Response>
         [JsonPropertyName("order_page")]
         public string OrderPage { get; set; }
 
-        [JsonPropertyName("pick_status")]
+        /// <summary>
+        /// Flag indicating the status of the order products collection (1 - all products collected, 0 - not all). API field: "pick_state".
+        /// </summary>
+        [JsonPropertyName("pick_state")]
         public int PickStatus { get; set; }
 
-        [JsonPropertyName("pack_status")]
+        /// <summary>
+        /// Flag indicating the status of the order products packing (1 - all products packed, 0 - not all). API field: "pack_state".
+        /// </summary>
+        [JsonPropertyName("pack_state")]
         public int PackStatus { get; set; }
 
         /// <summary>

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -320,16 +320,16 @@ public class GetOrders : IRequest<GetOrders.Response>
         public string OrderPage { get; set; }
 
         /// <summary>
-        /// Flag indicating the status of the order products collection (1 - all products collected, 0 - not all). API field: "pick_state".
+        /// Flag indicating the status of the order products collection (1 - all products collected, 0 - not all).
         /// </summary>
         [JsonPropertyName("pick_state")]
-        public int PickStatus { get; set; }
+        public int PickState { get; set; }
 
         /// <summary>
-        /// Flag indicating the status of the order products packing (1 - all products packed, 0 - not all). API field: "pack_state".
+        /// Flag indicating the status of the order products packing (1 - all products packed, 0 - not all).
         /// </summary>
         [JsonPropertyName("pack_state")]
-        public int PackStatus { get; set; }
+        public int PackState { get; set; }
 
         /// <summary>
         /// The commissions that the marketplace charges for an order. Returned only when commission data is requested (with_commission flag enabled).

--- a/BaseLinkerApi/Requests/Orders/GetOrders.cs
+++ b/BaseLinkerApi/Requests/Orders/GetOrders.cs
@@ -47,6 +47,18 @@ public class GetOrders : IRequest<GetOrders.Response>
     /// </summary>
     [JsonPropertyName("include_custom_extra_fields")]
     public bool? IncludeCustomExtraFields { get; set; }
+
+    /// <summary>
+    /// (optional, false by default) Download orders with commissions information. If set to true, the response will contain additional "commissions" field.
+    /// </summary>
+    [JsonPropertyName("include_commissions")]
+    public bool? IncludeCommissions { get; set; }
+
+    /// <summary>
+    /// (optional, false by default) Base Connect and contractor data. If set to true, the response will contain additional "connect_data" field.
+    /// </summary>
+    [JsonPropertyName("include_connect_data")]
+    public bool? IncludeConnectData { get; set; }
     
     /// <summary>
     /// (optional) The status identifier from which orders are to be collected. Leave blank to download orders from all statuses.
@@ -308,6 +320,12 @@ public class GetOrders : IRequest<GetOrders.Response>
         /// </summary>
         [JsonPropertyName("commissions")]
         public object Commissions { get; set; }
+
+        /// <summary>
+        /// Data from Base Connect linked to the order. Returned only when include_connect_data is set to true.
+        /// </summary>
+        [JsonPropertyName("connect_data")]
+        public object ConnectData { get; set; }
 
         [JsonPropertyName("products")]
         public List<Product> Products { get; set; }

--- a/BaseLinkerApi/Requests/Orders/SetOrdersMerge.cs
+++ b/BaseLinkerApi/Requests/Orders/SetOrdersMerge.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.Orders;
+
+/// <summary>
+/// Merges multiple orders into one, based on the selected merge mode.
+/// </summary>
+public class SetOrdersMerge : IRequest<SetOrdersMerge.Response>
+{
+    /// <summary>
+    /// ID of the main order (its shipping and invoice data will be retained).
+    /// </summary>
+    [JsonPropertyName("main_order_id")]
+    public int MainOrderId { get; set; }
+
+    /// <summary>
+    /// List of other order IDs to merge. Must not include main_order_id.
+    /// </summary>
+    [JsonPropertyName("order_ids_to_merge")]
+    public List<int> OrderIdsToMerge { get; set; }
+
+    /// <summary>
+    /// Merge mode: "technical_merge" (creates a new technical order without changing the originals)
+    /// or "into_main_order" (moves items into the main order and deletes the others).
+    /// </summary>
+    [JsonPropertyName("merge_mode")]
+    public string MergeMode { get; set; }
+
+    /// <summary>
+    /// Whether to sum delivery costs: true (add up all shipping costs from merged orders)
+    /// or false (keep only the main order's shipping cost).
+    /// </summary>
+    [JsonPropertyName("sum_delivery_costs")]
+    public bool SumDeliveryCosts { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// ID of the merged order
+        /// </summary>
+        [JsonPropertyName("merged_order_id")]
+        public int MergedOrderId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocument.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocument.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to create a new inventory document in BaseLinker storage.
+/// Documents are created as draft and need to be confirmed by the user or setInventoryDocumentStatusConfirmed API method.
+/// </summary>
+public class AddInventoryDocument : IRequest<AddInventoryDocument.Response>
+{
+    /// <summary>
+    /// Source warehouse identifier
+    /// </summary>
+    [JsonPropertyName("warehouse_id")]
+    public int WarehouseId { get; set; }
+
+    /// <summary>
+    /// Document type: 0 - GR (Goods Received), 1 - IGR (Internal Goods Received), 2 - GI (Goods Issue),
+    /// 3 - IGI (Internal Goods Issue), 4 - IT (Internal Transfer), 5 - OB (Opening Balance)
+    /// </summary>
+    [JsonPropertyName("document_type")]
+    public int DocumentType { get; set; }
+
+    /// <summary>
+    /// (optional) Target warehouse identifier - required only for transfer documents (type 4)
+    /// </summary>
+    [JsonPropertyName("target_warehouse_id")]
+    public int? TargetWarehouseId { get; set; }
+
+    /// <summary>
+    /// (optional) Date of document creation (unix timestamp). If not specified, the current date will be used.
+    /// </summary>
+    [JsonPropertyName("date_add")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? DateAdd { get; set; }
+
+    /// <summary>
+    /// (optional) Date of document execution (unix timestamp). If not specified, the current date will be used.
+    /// </summary>
+    [JsonPropertyName("date_execute")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? DateExecute { get; set; }
+
+    /// <summary>
+    /// (optional) Contractor description/notes
+    /// </summary>
+    [JsonPropertyName("contractor")]
+    public string? Contractor { get; set; }
+
+    /// <summary>
+    /// (optional) Related invoice number
+    /// </summary>
+    [JsonPropertyName("invoice_no")]
+    public string? InvoiceNo { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Created document identifier
+        /// </summary>
+        [JsonPropertyName("document_id")]
+        public int DocumentId { get; set; }
+
+        /// <summary>
+        /// Generated document number
+        /// </summary>
+        [JsonPropertyName("document_number")]
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocument.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocument.cs
@@ -56,6 +56,12 @@ public class AddInventoryDocument : IRequest<AddInventoryDocument.Response>
     [JsonPropertyName("invoice_no")]
     public string? InvoiceNo { get; set; }
 
+    /// <summary>
+    /// (optional) Document notes/description
+    /// </summary>
+    [JsonPropertyName("notes")]
+    public string? Notes { get; set; }
+
     public class Response : ResponseBase
     {
         /// <summary>

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocumentItems.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocumentItems.cs
@@ -42,6 +42,12 @@ public class AddInventoryDocumentItems : IRequest<AddInventoryDocumentItems.Resp
         public string? LocationName { get; set; }
 
         /// <summary>
+        /// (optional) Target storage location (only for Internal Transfer documents)
+        /// </summary>
+        [JsonPropertyName("target_location_name")]
+        public string? TargetLocationName { get; set; }
+
+        /// <summary>
         /// (optional) The expiry date. Date format YYYY-MM-DD (ISO 8601)
         /// </summary>
         [JsonPropertyName("expiry_date")]

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocumentItems.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryDocumentItems.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to add items to an existing inventory document.
+/// </summary>
+public class AddInventoryDocumentItems : IRequest<AddInventoryDocumentItems.Response>
+{
+    /// <summary>
+    /// Document identifier
+    /// </summary>
+    [JsonPropertyName("document_id")]
+    public int DocumentId { get; set; }
+
+    public class Item
+    {
+        /// <summary>
+        /// The product ID
+        /// </summary>
+        [JsonPropertyName("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// The quantity of this line item in the document
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// (optional) Item unit price
+        /// </summary>
+        [JsonPropertyName("price")]
+        public decimal? Price { get; set; }
+
+        /// <summary>
+        /// (optional) Source storage location
+        /// </summary>
+        [JsonPropertyName("location_name")]
+        public string? LocationName { get; set; }
+
+        /// <summary>
+        /// (optional) The expiry date. Date format YYYY-MM-DD (ISO 8601)
+        /// </summary>
+        [JsonPropertyName("expiry_date")]
+        public string? ExpiryDate { get; set; }
+
+        /// <summary>
+        /// (optional) Batch number
+        /// </summary>
+        [JsonPropertyName("batch")]
+        public string? Batch { get; set; }
+
+        /// <summary>
+        /// (optional) The product serial number
+        /// </summary>
+        [JsonPropertyName("serial_no")]
+        public string? SerialNo { get; set; }
+
+        /// <summary>
+        /// (optional) Item comments or notes
+        /// </summary>
+        [JsonPropertyName("comments")]
+        public string? Comments { get; set; }
+    }
+
+    /// <summary>
+    /// List of document items
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<Item> Items { get; set; }
+
+    public class Response : ResponseBase
+    {
+        public class CreatedItem
+        {
+            /// <summary>
+            /// Created item identifier
+            /// </summary>
+            [JsonPropertyName("item_id")]
+            public int ItemId { get; set; }
+        }
+
+        [JsonPropertyName("items")]
+        public List<CreatedItem> Items { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPayer.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPayer.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to add a new payer or update an existing one in BaseLinker storage.
+/// </summary>
+public class AddInventoryPayer : IRequest<AddInventoryPayer.Response>
+{
+    /// <summary>
+    /// (optional) Payer identifier. If provided, the existing payer will be updated.
+    /// </summary>
+    [JsonPropertyName("payer_id")]
+    public int? PayerId { get; set; }
+
+    /// <summary>
+    /// Payer name
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// (optional) Payer address
+    /// </summary>
+    [JsonPropertyName("address")]
+    public string? Address { get; set; }
+
+    /// <summary>
+    /// (optional) Payer postal code
+    /// </summary>
+    [JsonPropertyName("postcode")]
+    public string? Postcode { get; set; }
+
+    /// <summary>
+    /// (optional) Payer city
+    /// </summary>
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
+
+    /// <summary>
+    /// (optional) Payer tax identification number
+    /// </summary>
+    [JsonPropertyName("tax_no")]
+    public string? TaxNo { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Created or updated payer identifier
+        /// </summary>
+        [JsonPropertyName("payer_id")]
+        public int PayerId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
@@ -103,6 +103,13 @@ public class AddInventoryProduct : IRequest<AddInventoryProduct.Response>
     public double Length { get; set; }
 
     /// <summary>
+    /// Product average cost. If storage documents are turned off, this field sets product average cost.
+    /// If storage documents are turned on, a value in this field can be set in two cases: while creating a new product or when a current average cost is set to 0.
+    /// </summary>
+    [JsonPropertyName("average_cost")]
+    public decimal? AverageCost { get; set; }
+
+    /// <summary>
     /// Product star type. It takes from 0 to 5 values. 0 means no starring.
     /// </summary>
     [JsonPropertyName("star")]

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
@@ -203,6 +203,14 @@ public class AddInventoryProduct : IRequest<AddInventoryProduct.Response>
     public List<string> Images { get; set; }
 
     /// <summary>
+    /// A list of product videos (maximum 6), where the key is the 0-based video position (0-5).
+    /// Supported formats: MP4, WEBM (max 15 MB). The value can be a URL prefixed with "url:", base64-encoded binary data
+    /// prefixed with "data:", or an empty string "" to delete the video at the given position.
+    /// </summary>
+    [JsonPropertyName("videos")]
+    public Dictionary<int, string> Videos { get; set; }
+
+    /// <summary>
     /// An array containing product links to external warehouses (e.g. shops, wholesalers).
     /// Each element of the array is a list in which the key is the identifier of the external warehouse in the format "[type:shop|warehouse]_[id:int]". (e.g. "shop_2445").
     /// The warehouse identifiers can be retrieved with the getStoragesList method.

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
@@ -88,6 +88,12 @@ public class AddInventoryProduct : IRequest<AddInventoryProduct.Response>
     public List<AdditionalEan> EanAdditional { get; set; }
 
     /// <summary>
+    /// Product ASIN number.
+    /// </summary>
+    [JsonPropertyName("asin")]
+    public string Asin { get; set; }
+
+    /// <summary>
     /// A list containing tag names. Providing an empty list removes all existing tags from the product;
     /// omitting the field leaves existing tags unchanged.
     /// </summary>

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryProduct.cs
@@ -29,6 +29,21 @@ public class AddInventoryProduct : IRequest<AddInventoryProduct.Response>
         [JsonPropertyName("variant_id")]
         public int VariantId { get; set; }
     }
+
+    public class AdditionalEan
+    {
+        /// <summary>
+        /// EAN number
+        /// </summary>
+        [JsonPropertyName("ean")]
+        public string Ean { get; set; }
+
+        /// <summary>
+        /// Quantity of product with given EAN number
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+    }
         
     /// <summary>
     /// Catalog ID. The list of identifiers can be retrieved using the method getInventories. (inventory_id field).
@@ -65,6 +80,19 @@ public class AddInventoryProduct : IRequest<AddInventoryProduct.Response>
     /// </summary>
     [JsonPropertyName("ean")]
     public string Ean { get; set; }
+
+    /// <summary>
+    /// A list containing additional EAN numbers. Each element should contain an EAN number and the quantity of product with the given EAN number.
+    /// </summary>
+    [JsonPropertyName("ean_additional")]
+    public List<AdditionalEan> EanAdditional { get; set; }
+
+    /// <summary>
+    /// A list containing tag names. Providing an empty list removes all existing tags from the product;
+    /// omitting the field leaves existing tags unchanged.
+    /// </summary>
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; }
 
     /// <summary>
     /// Product SKU number.

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPurchaseOrder.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPurchaseOrder.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Text.Json.Serialization;
 using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
 
 namespace BaseLinkerApi.Requests.ProductCatalog;
 
@@ -49,6 +51,13 @@ public class AddInventoryPurchaseOrder : IRequest<AddInventoryPurchaseOrder.Resp
     /// </summary>
     [JsonPropertyName("invoice_no")]
     public string? InvoiceNo { get; set; }
+
+    /// <summary>
+    /// (optional) Expected delivery date (unix timestamp) set when creating the purchase order.
+    /// </summary>
+    [JsonPropertyName("date_delivery_expected")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? DateDeliveryExpected { get; set; }
 
     public class Response : ResponseBase
     {

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPurchaseOrder.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPurchaseOrder.cs
@@ -1,0 +1,67 @@
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to create a new purchase order in BaseLinker storage. Orders are created as drafts by default.
+/// </summary>
+public class AddInventoryPurchaseOrder : IRequest<AddInventoryPurchaseOrder.Response>
+{
+    /// <summary>
+    /// Warehouse identifier
+    /// </summary>
+    [JsonPropertyName("warehouse_id")]
+    public int WarehouseId { get; set; }
+
+    /// <summary>
+    /// Supplier identifier
+    /// </summary>
+    [JsonPropertyName("supplier_id")]
+    public int SupplierId { get; set; }
+
+    /// <summary>
+    /// Payer identifier
+    /// </summary>
+    [JsonPropertyName("payer_id")]
+    public int PayerId { get; set; }
+
+    /// <summary>
+    /// Order currency (e.g. EUR, USD)
+    /// </summary>
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; }
+
+    /// <summary>
+    /// (optional) Order name
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// (optional) Order description/notes
+    /// </summary>
+    [JsonPropertyName("notes")]
+    public string? Notes { get; set; }
+
+    /// <summary>
+    /// (optional) Related invoice number
+    /// </summary>
+    [JsonPropertyName("invoice_no")]
+    public string? InvoiceNo { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Created purchase order identifier
+        /// </summary>
+        [JsonPropertyName("order_id")]
+        public int OrderId { get; set; }
+
+        /// <summary>
+        /// Generated document number
+        /// </summary>
+        [JsonPropertyName("document_number")]
+        public string DocumentNumber { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPurchaseOrderItems.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventoryPurchaseOrderItems.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to add items to an existing purchase order. Entering the product with the ID and price updates
+/// the previously saved position only if all other parameters match. If any parameter differs (e.g. location), a new item will be added.
+/// </summary>
+public class AddInventoryPurchaseOrderItems : IRequest<AddInventoryPurchaseOrderItems.Response>
+{
+    /// <summary>
+    /// Purchase order identifier
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    public class Item
+    {
+        /// <summary>
+        /// Product identifier
+        /// </summary>
+        [JsonPropertyName("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// Item quantity
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// Item unit cost
+        /// </summary>
+        [JsonPropertyName("item_cost")]
+        public decimal ItemCost { get; set; }
+
+        /// <summary>
+        /// (optional) Product code from supplier
+        /// </summary>
+        [JsonPropertyName("supplier_code")]
+        public string? SupplierCode { get; set; }
+
+        /// <summary>
+        /// (optional) Storage location
+        /// </summary>
+        [JsonPropertyName("location")]
+        public string? Location { get; set; }
+
+        /// <summary>
+        /// (optional) Batch number
+        /// </summary>
+        [JsonPropertyName("batch")]
+        public string? Batch { get; set; }
+
+        /// <summary>
+        /// (optional) Expiry date
+        /// </summary>
+        [JsonPropertyName("expiry_date")]
+        public string? ExpiryDate { get; set; }
+
+        /// <summary>
+        /// (optional) Serial number
+        /// </summary>
+        [JsonPropertyName("serial_no")]
+        public string? SerialNo { get; set; }
+
+        /// <summary>
+        /// (optional) Item comments or notes
+        /// </summary>
+        [JsonPropertyName("comments")]
+        public string? Comments { get; set; }
+    }
+
+    /// <summary>
+    /// List of items to add.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public List<Item> Items { get; set; }
+
+    public class Response : ResponseBase
+    {
+        public class CreatedItem
+        {
+            /// <summary>
+            /// Item identifier
+            /// </summary>
+            [JsonPropertyName("item_id")]
+            public int ItemId { get; set; }
+
+            /// <summary>
+            /// Item position in order
+            /// </summary>
+            [JsonPropertyName("position")]
+            public int Position { get; set; }
+        }
+
+        [JsonPropertyName("items")]
+        public List<CreatedItem> Items { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventorySupplier.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventorySupplier.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to add a new supplier or update an existing one in BaseLinker storage.
+/// </summary>
+public class AddInventorySupplier : IRequest<AddInventorySupplier.Response>
+{
+    /// <summary>
+    /// (optional) Supplier identifier. If provided, the existing supplier will be updated.
+    /// </summary>
+    [JsonPropertyName("supplier_id")]
+    public int? SupplierId { get; set; }
+
+    /// <summary>
+    /// Supplier name
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Source of product cost for this supplier. Available values: "cost" (Product cost at the supplier), or price group ID.
+    /// Price group ids can be retrieved from the method getInventoryPriceGroups.
+    /// </summary>
+    [JsonPropertyName("take_product_cost_from")]
+    public string TakeProductCostFrom { get; set; }
+
+    /// <summary>
+    /// Source of product code for this supplier. Available values: "sku" (Product SKU), "ean" (Product EAN),
+    /// "code" (Product code at the supplier), or extra field ID. Extra field ids can be retrieved from the method getInventoryExtraFields.
+    /// </summary>
+    [JsonPropertyName("take_product_code_from")]
+    public string TakeProductCodeFrom { get; set; }
+
+    /// <summary>
+    /// (optional) Supplier address
+    /// </summary>
+    [JsonPropertyName("address")]
+    public string? Address { get; set; }
+
+    /// <summary>
+    /// (optional) Supplier postal code
+    /// </summary>
+    [JsonPropertyName("postcode")]
+    public string? Postcode { get; set; }
+
+    /// <summary>
+    /// (optional) Supplier city
+    /// </summary>
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
+
+    /// <summary>
+    /// (optional) Supplier phone number
+    /// </summary>
+    [JsonPropertyName("phone")]
+    public string? Phone { get; set; }
+
+    /// <summary>
+    /// (optional) Supplier email address
+    /// </summary>
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// (optional) Additional email addresses for correspondence
+    /// </summary>
+    [JsonPropertyName("email_copy_to")]
+    public string? EmailCopyTo { get; set; }
+
+    /// <summary>
+    /// (optional) Default supplier currency (e.g. EUR, USD)
+    /// </summary>
+    [JsonPropertyName("currency")]
+    public string? Currency { get; set; }
+
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// Created or updated supplier identifier
+        /// </summary>
+        [JsonPropertyName("supplier_id")]
+        public int SupplierId { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/AddInventorySupplier.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/AddInventorySupplier.cs
@@ -76,6 +76,12 @@ public class AddInventorySupplier : IRequest<AddInventorySupplier.Response>
     [JsonPropertyName("currency")]
     public string? Currency { get; set; }
 
+    /// <summary>
+    /// (optional) Supplier tax identification number
+    /// </summary>
+    [JsonPropertyName("tax_no")]
+    public string? TaxNo { get; set; }
+
     public class Response : ResponseBase
     {
         /// <summary>

--- a/BaseLinkerApi/Requests/ProductCatalog/DeleteInventoryPayer.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/DeleteInventoryPayer.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to remove a payer from BaseLinker storage.
+/// </summary>
+public class DeleteInventoryPayer : IRequest
+{
+    /// <summary>
+    /// Payer identifier
+    /// </summary>
+    [JsonPropertyName("payer_id")]
+    public int PayerId { get; set; }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/DeleteInventorySupplier.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/DeleteInventorySupplier.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to remove a supplier from BaseLinker storage.
+/// </summary>
+public class DeleteInventorySupplier : IRequest
+{
+    /// <summary>
+    /// Supplier identifier
+    /// </summary>
+    [JsonPropertyName("supplier_id")]
+    public int SupplierId { get; set; }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocumentItems.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocumentItems.cs
@@ -119,6 +119,12 @@ public class GetInventoryDocumentItems : IRequest<GetInventoryDocumentItems.Resp
         /// </summary>
         [JsonPropertyName("comments")]
         public string Comments { get; set; }
+
+        /// <summary>
+        /// The target location (only for Internal Transfer documents)
+        /// </summary>
+        [JsonPropertyName("target_location_name")]
+        public string TargetLocationName { get; set; }
     }
 
     public class Response : ResponseBase

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocumentItems.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocumentItems.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// This method allows you to retrieve document items for a specific inventory document in BaseLinker.
+/// In case of a large number of items, pagination is possible.
+/// </summary>
+public class GetInventoryDocumentItems : IRequest<GetInventoryDocumentItems.Response>
+{
+    /// <summary>
+    /// Inventory document ID
+    /// </summary>
+    [JsonPropertyName("document_id")]
+    public int DocumentId { get; set; }
+
+    /// <summary>
+    /// (optional) Results page number (100 items per page, numbered from 1)
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; set; }
+
+    public class Item
+    {
+        /// <summary>
+        /// The ID of the document to which this item belongs
+        /// </summary>
+        [JsonPropertyName("document_id")]
+        public int DocumentId { get; set; }
+
+        /// <summary>
+        /// The main identifier of the document item
+        /// </summary>
+        [JsonPropertyName("item_id")]
+        public int ItemId { get; set; }
+
+        /// <summary>
+        /// The line item number within the document
+        /// </summary>
+        [JsonPropertyName("position")]
+        public int Position { get; set; }
+
+        /// <summary>
+        /// The product ID
+        /// </summary>
+        [JsonPropertyName("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// The product name as copied at the time of document creation
+        /// </summary>
+        [JsonPropertyName("product_name")]
+        public string ProductName { get; set; }
+
+        /// <summary>
+        /// The product EAN
+        /// </summary>
+        [JsonPropertyName("product_ean")]
+        public string ProductEan { get; set; }
+
+        /// <summary>
+        /// The product SKU
+        /// </summary>
+        [JsonPropertyName("product_sku")]
+        public string ProductSku { get; set; }
+
+        /// <summary>
+        /// The quantity of this line item in the document
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// The unit price
+        /// </summary>
+        [JsonPropertyName("price")]
+        public decimal Price { get; set; }
+
+        /// <summary>
+        /// The total value of the item
+        /// </summary>
+        [JsonPropertyName("total_price")]
+        public decimal TotalPrice { get; set; }
+
+        /// <summary>
+        /// The catalog ID
+        /// </summary>
+        [JsonPropertyName("inventory_id")]
+        public int InventoryId { get; set; }
+
+        /// <summary>
+        /// The location
+        /// </summary>
+        [JsonPropertyName("location_name")]
+        public string LocationName { get; set; }
+
+        /// <summary>
+        /// The expiry date. Date format YYYY-MM-DD (ISO 8601)
+        /// </summary>
+        [JsonPropertyName("expiry_date")]
+        public string ExpiryDate { get; set; }
+
+        /// <summary>
+        /// The product batch
+        /// </summary>
+        [JsonPropertyName("batch")]
+        public string Batch { get; set; }
+
+        /// <summary>
+        /// The product serial number
+        /// </summary>
+        [JsonPropertyName("serial_no")]
+        public string SerialNo { get; set; }
+
+        /// <summary>
+        /// Item comments or notes
+        /// </summary>
+        [JsonPropertyName("comments")]
+        public string Comments { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("items")]
+        public List<Item> Items { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocumentSeries.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocumentSeries.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// This method allows you to retrieve information about available inventory document series in BaseLinker.
+/// Each series can be linked to a specific warehouse and can have its own numbering format settings.
+/// </summary>
+public class GetInventoryDocumentSeries : IRequest<GetInventoryDocumentSeries.Response>
+{
+    public class DocumentSeries
+    {
+        /// <summary>
+        /// Unique identifier of the series
+        /// </summary>
+        [JsonPropertyName("document_series_id")]
+        public int DocumentSeriesId { get; set; }
+
+        /// <summary>
+        /// The name of the series
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The type of document for which this series is intended: 0 - GR, 1 - IGR, 2 - GI, 3 - IGI, 4 - IT, 5 - OB
+        /// </summary>
+        [JsonPropertyName("document_type")]
+        public int DocumentType { get; set; }
+
+        /// <summary>
+        /// The warehouse ID to which this series applies
+        /// </summary>
+        [JsonPropertyName("warehouse_id")]
+        public int WarehouseId { get; set; }
+
+        /// <summary>
+        /// The format for document numbering
+        /// </summary>
+        [JsonPropertyName("format")]
+        public string Format { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("document_series")]
+        public List<DocumentSeries> DocumentSeries { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocuments.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocuments.cs
@@ -156,12 +156,14 @@ public class GetInventoryDocuments : IRequest<GetInventoryDocuments.Response>
         /// <summary>
         /// Source object type: 1-order, 2-purchase order, 3-stock take, 4-order return, 7-fulfillment delivery, 8-transfer
         /// </summary>
+        [Obsolete("Deprecated (changelog 2026-04-20). Use SourceObjectType instead.")]
         [JsonPropertyName("connection_type")]
         public int ConnectionType { get; set; }
 
         /// <summary>
         /// Source object ID
         /// </summary>
+        [Obsolete("Deprecated (changelog 2026-04-20). Use SourceObjectId instead.")]
         [JsonPropertyName("connection_id")]
         public int ConnectionId { get; set; }
 

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocuments.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocuments.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// This method allows you to retrieve a list of inventory documents from BaseLinker.
+/// It supports pagination and optional filtering by document type, date range, etc.
+/// </summary>
+public class GetInventoryDocuments : IRequest<GetInventoryDocuments.Response>
+{
+    /// <summary>
+    /// (optional) A specific inventory document ID
+    /// </summary>
+    [JsonPropertyName("filter_document_id")]
+    public int? FilterDocumentId { get; set; }
+
+    /// <summary>
+    /// (optional) The document type: 0 - GR (Goods Received), 1 - IGR (Internal Goods Received), 2 - GI (Goods Issue),
+    /// 3 - IGI (Internal Goods Issue), 4 - IT (Internal Transfer), 5 - OB (Opening Balance)
+    /// </summary>
+    [JsonPropertyName("filter_document_type")]
+    public int? FilterDocumentType { get; set; }
+
+    /// <summary>
+    /// (optional) The document status: 0 - Draft, 1 - Confirmed
+    /// </summary>
+    [JsonPropertyName("filter_document_status")]
+    public int? FilterDocumentStatus { get; set; }
+
+    /// <summary>
+    /// (optional) The minimum creation date (unix timestamp) to filter by
+    /// </summary>
+    [JsonPropertyName("filter_date_from")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? FilterDateFrom { get; set; }
+
+    /// <summary>
+    /// (optional) The maximum creation date (unix timestamp) to filter by
+    /// </summary>
+    [JsonPropertyName("filter_date_to")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? FilterDateTo { get; set; }
+
+    /// <summary>
+    /// (optional) The warehouse ID
+    /// </summary>
+    [JsonPropertyName("filter_warehouse_id")]
+    public int? FilterWarehouseId { get; set; }
+
+    /// <summary>
+    /// (optional) Results page number (100 documents per page, numbered from 1)
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; set; }
+
+    public class Document
+    {
+        /// <summary>
+        /// The unique identifier of the inventory document
+        /// </summary>
+        [JsonPropertyName("document_id")]
+        public int DocumentId { get; set; }
+
+        /// <summary>
+        /// The document type: 0-GR, 1-IGR, 2-GI, 3-IGI, 4-IT, 5-OB
+        /// </summary>
+        [JsonPropertyName("document_type")]
+        public int DocumentType { get; set; }
+
+        /// <summary>
+        /// The document status: 0 - Draft, 1 - Confirmed
+        /// </summary>
+        [JsonPropertyName("document_status")]
+        public int DocumentStatus { get; set; }
+
+        /// <summary>
+        /// The document direction (0 = incoming, 1 = outgoing)
+        /// </summary>
+        [JsonPropertyName("direction")]
+        public int Direction { get; set; }
+
+        /// <summary>
+        /// The ID of the document series
+        /// </summary>
+        [JsonPropertyName("document_series_id")]
+        public int DocumentSeriesId { get; set; }
+
+        /// <summary>
+        /// The full document number
+        /// </summary>
+        [JsonPropertyName("full_number")]
+        public string FullNumber { get; set; }
+
+        /// <summary>
+        /// The creation date of the document in unix time
+        /// </summary>
+        [JsonPropertyName("date_created")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateCreated { get; set; }
+
+        /// <summary>
+        /// The confirmation date in unix time. 0 if not confirmed
+        /// </summary>
+        [JsonPropertyName("date_confirmed")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateConfirmed { get; set; }
+
+        /// <summary>
+        /// The main warehouse ID used for this document
+        /// </summary>
+        [JsonPropertyName("warehouse_id")]
+        public int WarehouseId { get; set; }
+
+        /// <summary>
+        /// The second (destination) warehouse ID for transfers
+        /// </summary>
+        [JsonPropertyName("warehouse_id2")]
+        public int WarehouseId2 { get; set; }
+
+        /// <summary>
+        /// Number of items in the document
+        /// </summary>
+        [JsonPropertyName("items_count")]
+        public int ItemsCount { get; set; }
+
+        /// <summary>
+        /// Total quantity of products in the document
+        /// </summary>
+        [JsonPropertyName("total_quantity")]
+        public int TotalQuantity { get; set; }
+
+        /// <summary>
+        /// Total value (price) for the entire document
+        /// </summary>
+        [JsonPropertyName("total_price")]
+        public decimal TotalPrice { get; set; }
+
+        /// <summary>
+        /// Source object type: 1-order, 2-purchase order, 3-stock take, 4-order return, 7-fulfillment delivery, 8-transfer
+        /// </summary>
+        [JsonPropertyName("connection_type")]
+        public int ConnectionType { get; set; }
+
+        /// <summary>
+        /// Source object ID
+        /// </summary>
+        [JsonPropertyName("connection_id")]
+        public int ConnectionId { get; set; }
+
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("documents")]
+        public List<Document> Documents { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocuments.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryDocuments.cs
@@ -14,6 +14,19 @@ namespace BaseLinkerApi.Requests.ProductCatalog;
 public class GetInventoryDocuments : IRequest<GetInventoryDocuments.Response>
 {
     /// <summary>
+    /// (optional) The source object type to filter by: 1 - order, 2 - purchase order, 3 - stock take,
+    /// 4 - order return, 7 - fulfillment delivery, 8 - transfer
+    /// </summary>
+    [JsonPropertyName("filter_source_object_type")]
+    public int? FilterSourceObjectType { get; set; }
+
+    /// <summary>
+    /// (optional) The source object ID to filter by
+    /// </summary>
+    [JsonPropertyName("filter_source_object_id")]
+    public int? FilterSourceObjectId { get; set; }
+
+    /// <summary>
     /// (optional) A specific inventory document ID
     /// </summary>
     [JsonPropertyName("filter_document_id")]
@@ -151,6 +164,25 @@ public class GetInventoryDocuments : IRequest<GetInventoryDocuments.Response>
         /// </summary>
         [JsonPropertyName("connection_id")]
         public int ConnectionId { get; set; }
+
+        /// <summary>
+        /// Document notes/comments
+        /// </summary>
+        [JsonPropertyName("notes")]
+        public string Notes { get; set; }
+
+        /// <summary>
+        /// Type of source object that created this document: 0-no source, 1-order, 2-purchase order, 3-stock take,
+        /// 4-order return, 7-fulfillment delivery, 8-transfer
+        /// </summary>
+        [JsonPropertyName("source_object_type")]
+        public int SourceObjectType { get; set; }
+
+        /// <summary>
+        /// ID of the source object. 0 if no source
+        /// </summary>
+        [JsonPropertyName("source_object_id")]
+        public int SourceObjectId { get; set; }
 
         /// <summary>
         /// Additional not parsed data

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPayers.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPayers.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to retrieve a list of payers available in BaseLinker storage.
+/// </summary>
+public class GetInventoryPayers : IRequest<GetInventoryPayers.Response>
+{
+    /// <summary>
+    /// (optional) Limiting results to a specific payer ID
+    /// </summary>
+    [JsonPropertyName("filter_id")]
+    public int? FilterId { get; set; }
+
+    /// <summary>
+    /// (optional) Filtering by payer name (full or partial match)
+    /// </summary>
+    [JsonPropertyName("filter_name")]
+    public string? FilterName { get; set; }
+
+    public class Payer
+    {
+        /// <summary>
+        /// Payer identifier
+        /// </summary>
+        [JsonPropertyName("payer_id")]
+        public int PayerId { get; set; }
+
+        /// <summary>
+        /// Payer name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// (optional) Payer address
+        /// </summary>
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        /// <summary>
+        /// (optional) Payer postal code
+        /// </summary>
+        [JsonPropertyName("postcode")]
+        public string Postcode { get; set; }
+
+        /// <summary>
+        /// (optional) Payer city
+        /// </summary>
+        [JsonPropertyName("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// (optional) Payer tax identification number
+        /// </summary>
+        [JsonPropertyName("tax_no")]
+        public string TaxNo { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("payers")]
+        public List<Payer> Payers { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPrintoutTemplates.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPrintoutTemplates.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// Returns a list of all configured printout templates available for inventory (products).
+/// </summary>
+public class GetInventoryPrintoutTemplates : IRequest<GetInventoryPrintoutTemplates.Response>
+{
+    public class Printout
+    {
+        /// <summary>
+        /// Unique identifier of the printout template
+        /// </summary>
+        [JsonPropertyName("printout_id")]
+        public int PrintoutId { get; set; }
+
+        /// <summary>
+        /// Name of the printout template
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Output format (e.g. PDF, HTML, XLS)
+        /// </summary>
+        [JsonPropertyName("file_format")]
+        public string FileFormat { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("printouts")]
+        public List<Printout> Printouts { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
@@ -179,6 +179,12 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
         [JsonPropertyName("images")]
         public Dictionary<string, string> Images { get; set; }
 
+        /// <summary>
+        /// A list of product videos where the key is the 1-based video position (1-6) and the value is the video URL.
+        /// </summary>
+        [JsonPropertyName("videos")]
+        public Dictionary<int, string> Videos { get; set; }
+
         [JsonPropertyName("links")]
         public Dictionary<string, Link> Links { get; set; }
             

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
@@ -27,6 +27,27 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
     [JsonPropertyName("include_erp_units")]
     public bool? IncludeErpUnits { get; set; }
 
+    /// <summary>
+    /// (optional) Include additional EANs in response. User can set additional EANs for product, to work with products cases (4-pack etc.) or different regional codes for the same product.
+    /// </summary>
+    [JsonPropertyName("include_additional_eans")]
+    public bool? IncludeAdditionalEans { get; set; }
+
+    public class AdditionalEan
+    {
+        /// <summary>
+        /// EAN number
+        /// </summary>
+        [JsonPropertyName("ean")]
+        public string Ean { get; set; }
+
+        /// <summary>
+        /// Quantity of product with given EAN number
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+    }
+
     public class StockErpUnit
     {
         /// <summary>
@@ -82,10 +103,22 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
     {
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
-            
+
+        /// <summary>
+        /// A list containing additional EAN numbers (returned only if include_additional_eans is set to true).
+        /// </summary>
+        [JsonPropertyName("ean_additional")]
+        public List<AdditionalEan> EanAdditional { get; set; }
+
+        /// <summary>
+        /// A list of product tags.
+        /// </summary>
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; }
+
         [JsonPropertyName("sku")]
         public string Sku { get; set; }
-            
+
         [JsonPropertyName("tax_rate")]
         public double TaxRate { get; set; }
             

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
@@ -21,6 +21,33 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
     [JsonPropertyName("products")]
     public List<int> Products { get; set; }
 
+    /// <summary>
+    /// (optional) Include ERP units in the response. Only available for inventories with purchase cost calculations system different than AVCO.
+    /// </summary>
+    [JsonPropertyName("include_erp_units")]
+    public bool? IncludeErpUnits { get; set; }
+
+    public class StockErpUnit
+    {
+        /// <summary>
+        /// Quantity of given ERP unit
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// Purchase cost of given ERP unit
+        /// </summary>
+        [JsonPropertyName("purchase_cost")]
+        public double PurchaseCost { get; set; }
+
+        /// <summary>
+        /// Expiry date of given ERP unit
+        /// </summary>
+        [JsonPropertyName("expiry_date")]
+        public string ExpiryDate { get; set; }
+    }
+
     public class Link
     {
         [JsonPropertyName("product_id")]
@@ -109,6 +136,12 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
             
         [JsonPropertyName("variants")]
         public Dictionary<int, Variant> Variants { get; set; }
+
+        /// <summary>
+        /// A list containing products stock erp units, where the key is the warehouse ID and value is a list of units in given warehouse.
+        /// </summary>
+        [JsonPropertyName("stock_erp_units")]
+        public Dictionary<string, List<StockErpUnit>> StockErpUnits { get; set; }
     }
         
     public class Response : ResponseBase

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
@@ -104,6 +104,12 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
     
     public class Product
     {
+        /// <summary>
+        /// Product parent ID. Returns 0 for main products, or the main product ID for variants.
+        /// </summary>
+        [JsonPropertyName("parent_id")]
+        public int ParentId { get; set; }
+
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
 

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsData.cs
@@ -82,7 +82,10 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
     {
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
-            
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
+
         [JsonPropertyName("sku")]
         public string Sku { get; set; }
             
@@ -109,6 +112,12 @@ public class GetInventoryProductsData : IRequest<GetInventoryProductsData.Respon
         /// </summary>
         [JsonPropertyName("ean_additional")]
         public List<AdditionalEan> EanAdditional { get; set; }
+
+        /// <summary>
+        /// Product ASIN number (primary ASIN).
+        /// </summary>
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
 
         /// <summary>
         /// A list of product tags.

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsList.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsList.cs
@@ -88,7 +88,10 @@ public class GetInventoryProductsList : IRequest<GetInventoryProductsList.Respon
             
         [JsonPropertyName("sku")]
         public string Sku { get; set; }
-            
+
+        [JsonPropertyName("asin")]
+        public string Asin { get; set; }
+
         [JsonPropertyName("name")]
         public string Name { get; set; }
             

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsList.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryProductsList.cs
@@ -82,7 +82,13 @@ public class GetInventoryProductsList : IRequest<GetInventoryProductsList.Respon
     {
         [JsonPropertyName("id")]
         public int Id { get; set; }
-        
+
+        /// <summary>
+        /// Product parent ID. Returns 0 for main products, or the main product ID for variants.
+        /// </summary>
+        [JsonPropertyName("parent_id")]
+        public int ParentId { get; set; }
+
         [JsonPropertyName("ean")]
         public string Ean { get; set; }
             

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrderItems.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrderItems.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to retrieve items from a specific purchase order.
+/// </summary>
+public class GetInventoryPurchaseOrderItems : IRequest<GetInventoryPurchaseOrderItems.Response>
+{
+    /// <summary>
+    /// Purchase order identifier
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    /// <summary>
+    /// (optional) Page number of the results if there are many items in a purchase order (100 items per page).
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; set; }
+
+    public class Item
+    {
+        /// <summary>
+        /// Item identifier
+        /// </summary>
+        [JsonPropertyName("item_id")]
+        public int ItemId { get; set; }
+
+        /// <summary>
+        /// Product identifier
+        /// </summary>
+        [JsonPropertyName("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// The line item number within the purchase order
+        /// </summary>
+        [JsonPropertyName("position")]
+        public int Position { get; set; }
+
+        /// <summary>
+        /// Product name on document
+        /// </summary>
+        [JsonPropertyName("product_name")]
+        public string ProductName { get; set; }
+
+        /// <summary>
+        /// Product SKU
+        /// </summary>
+        [JsonPropertyName("product_sku")]
+        public string ProductSku { get; set; }
+
+        /// <summary>
+        /// Product EAN
+        /// </summary>
+        [JsonPropertyName("product_ean")]
+        public string ProductEan { get; set; }
+
+        /// <summary>
+        /// (optional) Product code from supplier
+        /// </summary>
+        [JsonPropertyName("supplier_code")]
+        public string SupplierCode { get; set; }
+
+        /// <summary>
+        /// Ordered quantity
+        /// </summary>
+        [JsonPropertyName("quantity")]
+        public int Quantity { get; set; }
+
+        /// <summary>
+        /// Received quantity
+        /// </summary>
+        [JsonPropertyName("completed_quantity")]
+        public int CompletedQuantity { get; set; }
+
+        /// <summary>
+        /// Item unit cost
+        /// </summary>
+        [JsonPropertyName("item_cost")]
+        public decimal ItemCost { get; set; }
+
+        /// <summary>
+        /// (optional) Storage location
+        /// </summary>
+        [JsonPropertyName("location")]
+        public string Location { get; set; }
+
+        /// <summary>
+        /// (optional) Expiry date
+        /// </summary>
+        [JsonPropertyName("expiry_date")]
+        public string ExpiryDate { get; set; }
+
+        /// <summary>
+        /// (optional) Batch number
+        /// </summary>
+        [JsonPropertyName("batch")]
+        public string Batch { get; set; }
+
+        /// <summary>
+        /// (optional) Serial number
+        /// </summary>
+        [JsonPropertyName("serial_no")]
+        public string SerialNo { get; set; }
+
+        /// <summary>
+        /// (optional) Item comments or notes
+        /// </summary>
+        [JsonPropertyName("comments")]
+        public string Comments { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("items")]
+        public List<Item> Items { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrderSeries.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrderSeries.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to retrieve a list of purchase order document series available in BaseLinker storage.
+/// </summary>
+public class GetInventoryPurchaseOrderSeries : IRequest<GetInventoryPurchaseOrderSeries.Response>
+{
+    /// <summary>
+    /// (optional) Filter series by warehouse ID
+    /// </summary>
+    [JsonPropertyName("warehouse_id")]
+    public int? WarehouseId { get; set; }
+
+    public class Series
+    {
+        /// <summary>
+        /// Series identifier
+        /// </summary>
+        [JsonPropertyName("series_id")]
+        public int SeriesId { get; set; }
+
+        /// <summary>
+        /// Series name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Warehouse identifier
+        /// </summary>
+        [JsonPropertyName("warehouse_id")]
+        public int WarehouseId { get; set; }
+
+        /// <summary>
+        /// Document number format
+        /// </summary>
+        [JsonPropertyName("format")]
+        public string Format { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("series")]
+        public List<Series> Series { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrders.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrders.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+using BaseLinkerApi.Common.JsonConverters;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to retrieve a list of purchase orders from BaseLinker storage.
+/// </summary>
+public class GetInventoryPurchaseOrders : IRequest<GetInventoryPurchaseOrders.Response>
+{
+    /// <summary>
+    /// (optional) Warehouse ID. The list of identifiers can be retrieved using the method getInventoryWarehouses.
+    /// </summary>
+    [JsonPropertyName("warehouse_id")]
+    public int? WarehouseId { get; set; }
+
+    /// <summary>
+    /// (optional) Limiting results to a specific supplier ID
+    /// </summary>
+    [JsonPropertyName("supplier_id")]
+    public int? SupplierId { get; set; }
+
+    /// <summary>
+    /// (optional) Limiting results to a specific document series ID
+    /// </summary>
+    [JsonPropertyName("series_id")]
+    public int? SeriesId { get; set; }
+
+    /// <summary>
+    /// (optional) Date from which documents should be retrieved (Unix timestamp)
+    /// </summary>
+    [JsonPropertyName("date_from")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? DateFrom { get; set; }
+
+    /// <summary>
+    /// (optional) Date up to which documents should be retrieved (Unix timestamp)
+    /// </summary>
+    [JsonPropertyName("date_to")]
+    [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+    public DateTimeOffset? DateTo { get; set; }
+
+    /// <summary>
+    /// (optional) Filtering by document number (full or partial match)
+    /// </summary>
+    [JsonPropertyName("filter_document_number")]
+    public string? FilterDocumentNumber { get; set; }
+
+    /// <summary>
+    /// (optional) Results paging (100 documents per page)
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; set; }
+
+    public class PurchaseOrder
+    {
+        /// <summary>
+        /// Purchase order identifier
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Purchase order name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Purchase order series identifier
+        /// </summary>
+        [JsonPropertyName("series_id")]
+        public int SeriesId { get; set; }
+
+        /// <summary>
+        /// Full document number
+        /// </summary>
+        [JsonPropertyName("document_number")]
+        public string DocumentNumber { get; set; }
+
+        /// <summary>
+        /// Purchase order creation date (Unix timestamp)
+        /// </summary>
+        [JsonPropertyName("date_created")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateCreated { get; set; }
+
+        /// <summary>
+        /// Purchase order sent date (Unix timestamp)
+        /// </summary>
+        [JsonPropertyName("date_sent")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset DateSent { get; set; }
+
+        /// <summary>
+        /// (optional) Purchase order received date (Unix timestamp)
+        /// </summary>
+        [JsonPropertyName("date_received")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset? DateReceived { get; set; }
+
+        /// <summary>
+        /// (optional) Purchase order completed date (Unix timestamp)
+        /// </summary>
+        [JsonPropertyName("date_completed")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset? DateCompleted { get; set; }
+
+        /// <summary>
+        /// Warehouse identifier
+        /// </summary>
+        [JsonPropertyName("warehouse_id")]
+        public int WarehouseId { get; set; }
+
+        /// <summary>
+        /// Supplier identifier
+        /// </summary>
+        [JsonPropertyName("supplier_id")]
+        public int SupplierId { get; set; }
+
+        /// <summary>
+        /// (optional) Payer identifier
+        /// </summary>
+        [JsonPropertyName("payer_id")]
+        public int? PayerId { get; set; }
+
+        /// <summary>
+        /// Purchase order currency (e.g. EUR, USD)
+        /// </summary>
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Total quantity of items
+        /// </summary>
+        [JsonPropertyName("total_quantity")]
+        public int TotalQuantity { get; set; }
+
+        /// <summary>
+        /// Total quantity of received items
+        /// </summary>
+        [JsonPropertyName("completed_total_quantity")]
+        public int CompletedTotalQuantity { get; set; }
+
+        /// <summary>
+        /// Total order cost
+        /// </summary>
+        [JsonPropertyName("total_cost")]
+        public decimal TotalCost { get; set; }
+
+        /// <summary>
+        /// Total cost of received items
+        /// </summary>
+        [JsonPropertyName("completed_total_cost")]
+        public decimal CompletedTotalCost { get; set; }
+
+        /// <summary>
+        /// Number of unique items in purchase order
+        /// </summary>
+        [JsonPropertyName("items_count")]
+        public int ItemsCount { get; set; }
+
+        /// <summary>
+        /// Number of unique items received
+        /// </summary>
+        [JsonPropertyName("completed_items_count")]
+        public int CompletedItemsCount { get; set; }
+
+        /// <summary>
+        /// (optional) Related invoice number
+        /// </summary>
+        [JsonPropertyName("cost_invoice_no")]
+        public string CostInvoiceNo { get; set; }
+
+        /// <summary>
+        /// (optional) Purchase order notes/description
+        /// </summary>
+        [JsonPropertyName("notes")]
+        public string Notes { get; set; }
+
+        /// <summary>
+        /// Order status. 0 - draft, 1 - sent, 2 - received, 3 - completed, 4 - completed partially, 5 - canceled
+        /// </summary>
+        [JsonPropertyName("status")]
+        public int Status { get; set; }
+
+        /// <summary>
+        /// Additional not parsed data
+        /// </summary>
+        [JsonExtensionData] public Dictionary<string, JsonElement>? ExtensionsData { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("purchase_orders")]
+        public List<PurchaseOrder> PurchaseOrders { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrders.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrders.cs
@@ -56,6 +56,21 @@ public class GetInventoryPurchaseOrders : IRequest<GetInventoryPurchaseOrders.Re
     [JsonPropertyName("page")]
     public int? Page { get; set; }
 
+    public class AdditionalCost
+    {
+        /// <summary>
+        /// Additional cost name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Additional cost value
+        /// </summary>
+        [JsonPropertyName("cost")]
+        public decimal Cost { get; set; }
+    }
+
     public class PurchaseOrder
     {
         /// <summary>
@@ -111,6 +126,13 @@ public class GetInventoryPurchaseOrders : IRequest<GetInventoryPurchaseOrders.Re
         public DateTimeOffset? DateCompleted { get; set; }
 
         /// <summary>
+        /// (optional) Expected delivery date (Unix timestamp)
+        /// </summary>
+        [JsonPropertyName("date_expected_delivery")]
+        [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
+        public DateTimeOffset? DateExpectedDelivery { get; set; }
+
+        /// <summary>
         /// Warehouse identifier
         /// </summary>
         [JsonPropertyName("warehouse_id")]
@@ -153,6 +175,12 @@ public class GetInventoryPurchaseOrders : IRequest<GetInventoryPurchaseOrders.Re
         public decimal TotalCost { get; set; }
 
         /// <summary>
+        /// (optional) List of additional costs assigned to the purchase order.
+        /// </summary>
+        [JsonPropertyName("additional_cost")]
+        public List<AdditionalCost> AdditionalCost { get; set; }
+
+        /// <summary>
         /// Total cost of received items
         /// </summary>
         [JsonPropertyName("completed_total_cost")]
@@ -175,6 +203,12 @@ public class GetInventoryPurchaseOrders : IRequest<GetInventoryPurchaseOrders.Re
         /// </summary>
         [JsonPropertyName("cost_invoice_no")]
         public string CostInvoiceNo { get; set; }
+
+        /// <summary>
+        /// (optional) URL to download uploaded cost invoice file
+        /// </summary>
+        [JsonPropertyName("cost_invoice_file")]
+        public string CostInvoiceFile { get; set; }
 
         /// <summary>
         /// (optional) Purchase order notes/description

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrders.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryPurchaseOrders.cs
@@ -51,6 +51,12 @@ public class GetInventoryPurchaseOrders : IRequest<GetInventoryPurchaseOrders.Re
     public string? FilterDocumentNumber { get; set; }
 
     /// <summary>
+    /// (optional) Limiting results to purchase orders containing a product with the given ID
+    /// </summary>
+    [JsonPropertyName("filter_product_id")]
+    public int? FilterProductId { get; set; }
+
+    /// <summary>
     /// (optional) Results paging (100 documents per page)
     /// </summary>
     [JsonPropertyName("page")]

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventorySuppliers.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventorySuppliers.cs
@@ -76,6 +76,12 @@ public class GetInventorySuppliers : IRequest<GetInventorySuppliers.Response>
         /// </summary>
         [JsonPropertyName("currency")]
         public string Currency { get; set; }
+
+        /// <summary>
+        /// (optional) Supplier tax identification number
+        /// </summary>
+        [JsonPropertyName("tax_no")]
+        public string TaxNo { get; set; }
     }
 
     public class Response : ResponseBase

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventorySuppliers.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventorySuppliers.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to retrieve a list of suppliers available in BaseLinker storage.
+/// </summary>
+public class GetInventorySuppliers : IRequest<GetInventorySuppliers.Response>
+{
+    /// <summary>
+    /// (optional) Limiting results to a specific supplier ID
+    /// </summary>
+    [JsonPropertyName("filter_id")]
+    public int? FilterId { get; set; }
+
+    /// <summary>
+    /// (optional) Filtering by supplier name (full or partial match)
+    /// </summary>
+    [JsonPropertyName("filter_name")]
+    public string? FilterName { get; set; }
+
+    public class Supplier
+    {
+        /// <summary>
+        /// Supplier identifier
+        /// </summary>
+        [JsonPropertyName("supplier_id")]
+        public int SupplierId { get; set; }
+
+        /// <summary>
+        /// Supplier name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// (optional) Supplier address
+        /// </summary>
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        /// <summary>
+        /// (optional) Supplier postal code
+        /// </summary>
+        [JsonPropertyName("postcode")]
+        public string Postcode { get; set; }
+
+        /// <summary>
+        /// (optional) Supplier city
+        /// </summary>
+        [JsonPropertyName("city")]
+        public string City { get; set; }
+
+        /// <summary>
+        /// (optional) Supplier phone number
+        /// </summary>
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        /// <summary>
+        /// (optional) Supplier email address
+        /// </summary>
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// (optional) Additional email addresses for correspondence
+        /// </summary>
+        [JsonPropertyName("email_copy_to")]
+        public string EmailCopyTo { get; set; }
+
+        /// <summary>
+        /// (optional) Default supplier currency (e.g. EUR, USD)
+        /// </summary>
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+    }
+
+    public class Response : ResponseBase
+    {
+        [JsonPropertyName("suppliers")]
+        public List<Supplier> Suppliers { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/GetInventoryTags.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/GetInventoryTags.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using BaseLinkerApi.Common;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to retrieve a list of tags for a BaseLinker catalog.
+/// </summary>
+public class GetInventoryTags : IRequest<GetInventoryTags.Response>
+{
+    public class Response : ResponseBase
+    {
+        /// <summary>
+        /// A list containing available tags.
+        /// </summary>
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; }
+    }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/SetInventoryDocumentStatusConfirmed.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/SetInventoryDocumentStatusConfirmed.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to confirm an inventory document, which will affect the stock levels in the warehouse.
+/// </summary>
+public class SetInventoryDocumentStatusConfirmed : IRequest
+{
+    /// <summary>
+    /// Document identifier
+    /// </summary>
+    [JsonPropertyName("document_id")]
+    public int DocumentId { get; set; }
+}

--- a/BaseLinkerApi/Requests/ProductCatalog/SetInventoryPurchaseOrderStatus.cs
+++ b/BaseLinkerApi/Requests/ProductCatalog/SetInventoryPurchaseOrderStatus.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace BaseLinkerApi.Requests.ProductCatalog;
+
+/// <summary>
+/// The method allows you to change the status of a purchase order.
+/// </summary>
+public class SetInventoryPurchaseOrderStatus : IRequest
+{
+    /// <summary>
+    /// Purchase order identifier
+    /// </summary>
+    [JsonPropertyName("order_id")]
+    public int OrderId { get; set; }
+
+    /// <summary>
+    /// New order status. Available values: 0 - draft, 1 - sent, 2 - received, 3 - completed, 4 - completed partially, 5 - canceled
+    /// </summary>
+    [JsonPropertyName("status")]
+    public int Status { get; set; }
+
+    public class CompletedItem
+    {
+        /// <summary>
+        /// Item identifier
+        /// </summary>
+        [JsonPropertyName("item_id")]
+        public int ItemId { get; set; }
+
+        /// <summary>
+        /// Received quantity
+        /// </summary>
+        [JsonPropertyName("completed_quantity")]
+        public int CompletedQuantity { get; set; }
+    }
+
+    /// <summary>
+    /// (optional) List of items received.
+    /// </summary>
+    [JsonPropertyName("completed_items")]
+    public List<CompletedItem> CompletedItems { get; set; }
+}

--- a/ExampleConsoleApp/ExampleConsoleApp.csproj
+++ b/ExampleConsoleApp/ExampleConsoleApp.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>default</LangVersion>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Base.com API client for .NET
 [![NuGet](https://img.shields.io/nuget/v/BaseLinker)](https://www.nuget.org/packages/BaseLinker/)
-[![Conforms to the update](https://img.shields.io/badge/update-2023--08--23-brightgreen)](https://api.baselinker.com/index.php?changelog)
+[![Conforms to the update](https://img.shields.io/badge/update-2026--06--01-brightgreen)](https://api.baselinker.com/index.php?changelog)
 [![Sponsor](https://img.shields.io/github/sponsors/bugproof)](https://github.com/sponsors/bugproof)
 [![NuGet downloads](https://img.shields.io/nuget/dt/BaseLinker.svg)](https://www.nuget.org/packages/BaseLinker/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://base.com/assets/images/favicons/base.com/apple-touch-icon-57x57.png)
+![](https://base.com/assets/images/favicons/base.com/apple-touch-icon-120x120.png)
 
 # Base.com API client for .NET
 [![NuGet](https://img.shields.io/nuget/v/BaseLinker)](https://www.nuget.org/packages/BaseLinker/)


### PR DESCRIPTION
## Summary

Brings the library up to date with the [BaseLinker API changelog](https://api.baselinker.com/index.php?changelog) — every entry **after 2023-08-23** (the previous conformance point) is implemented as its **own commit**, in chronological order (2024-01-10 → 2026-06-01). Also modernizes the toolchain and cuts a **1.0.0** release.

## Changelog implementation (28 entries)

New API categories added (following the existing `IRequest<Response>` + `[JsonPropertyName]` conventions):

- **Order Returns** — `addOrderReturn`, `getOrderReturns`, `setOrderReturnFields`, `addOrderReturnProduct`, `deleteOrderReturnProduct`, `setOrderReturnProductFields`, status/reason/extra-field lookups, payments history, refund, journal, macro trigger (16 methods)
- **Base Connect** — `getConnectIntegrations`, `getConnectIntegrationContractors`, `getConnectContractorCreditHistory`, `addConnectContractorCredit` (deprecated 2025-10-21), `setConnectContractorCreditLimit`
- **CRM** — `addCrmClient`, `deleteCrmClient`, `getCrmClients`, `getCrmClientData`, `getCrmClientStatuses`, `getCrmClientStatusGroups`
- **Purchase orders / inventory documents / suppliers / payers** under ProductCatalog, plus `getOrderPickPackHistory`, `getOrderTransactionData` (replaces deprecated `getOrderTransactionDetails`), `setOrdersMerge`, `addOrderDuplicate`, `addOrderBySplit`, `getPackageDetails`, printout templates, ASIN support, product videos, etc.

Field-level additions (e.g. `average_cost`, `tags`, `ean_additional`, `stock_erp_units`, `parent_id`, `target_location_name`, `refund_done`, `commissions`/`connect_data`) land in the exact commit their changelog entry introduced them; deprecations are marked `[Obsolete]`; the 2024-10-10 Base Connect parameter renames are a real rename commit on top of the 2024-06-05 creation.

## Modernization

- Target frameworks: drop EOL `net5.0/6.0/7.0` → **`netstandard2.0;net8.0;net10.0`**
- Dependencies → latest **10.0.8** (System.Text.Json/System.Net.Http.Json/System.Threading.RateLimiting, Microsoft.Extensions.*); **clears the System.Text.Json 7.0.2 advisory GHSA-hh2w-p6rv-4g7w**
- Test stack upgraded (Test.Sdk 18.6.0, xunit 2.9.3, runner 3.1.5, coverlet 10.0.1); tests/example retargeted to net10.0
- CI: publish workflow bumped to .NET 10 SDK (`10.0.x`) and refreshed `actions/checkout@v4` / `setup-dotnet@v4` (the old 7.0.202 SDK can't build net8/net10)
- Icon/metadata fixes (README 120×120 icon, DI package icon + repo URL)

## Breaking changes → 1.0.0

- Dropped EOL target frameworks (consumers on net5/6/7 still resolve via `netstandard2.0`)
- Renamed properties whose JSON mappings were corrected: `GetOrders.Order.PickStatus`→`PickState`, `PackStatus`→`PackState`, `GetJournalList…Log.LogId`→`Id`

## Pre-existing bug fixes

Three fields had `[JsonPropertyName]` mappings that never bound (silently stayed at defaults), surfaced by spec verification and confirmed by the repo's own test fixture: `pick_status`→`pick_state`, `pack_status`→`pack_state`, journal `log_id`→`id`.

## Also includes #36

Government-invoice support in `getInvoices` (`get_government_data` + `gov_id`/`gov_date`/`gov_status`), verified against the live API docs. The csproj changes from #36 were omitted as superseded by the modernization here. Closes #36.

## Verification

- Full solution builds clean on all three target frameworks (0 errors)
- A 63-agent pass diffing every implemented method against the live API docs found **no defects in the new code**
- Test suite runs on net10.0 (the one failing test, `Issue21`, is a pre-existing fixture issue unrelated to these changes — it also fails on `master`)
