### PR TITLE
Publish DI extension in CI and align it to 1.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,3 +40,13 @@ jobs:
 
           # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
           # INCLUDE_SYMBOLS: false
+
+      - name: Publish DI extensions on version change
+        id: publish_nuget_di
+        uses: alirezanet/publish-nuget@v3.0.4
+        with:
+          PROJECT_FILE_PATH: BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
+          PACKAGE_NAME: BaseLinker.Extensions.DependencyInjection
+          VERSION_REGEX: ^\s*<PackageVersion>(.*)<\/PackageVersion>\s*$
+          TAG_COMMIT: false
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
+++ b/BaseLinkerApi.Extensions.DependencyInjection/BaseLinkerApi.Extensions.DependencyInjection.csproj
@@ -9,8 +9,8 @@
         <AssemblyName>BaseLinker.Extensions.DependencyInjection</AssemblyName>
 
         <PackageId>BaseLinker.Extensions.DependencyInjection</PackageId>
-        <Description>BaseLinker.com API client library (dependency injection extensions)</Description>
-        <PackageVersion>0.3.0</PackageVersion>
+        <Description>Base.com API client library (dependency injection extensions)</Description>
+        <PackageVersion>1.0.0</PackageVersion>
         <PackageTags>ecommerce;e-commerce;baselinker</PackageTags>
         <RepositoryUrl>https://github.com/bugproof/baselinker-dotnet</RepositoryUrl>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Follow-up to #37.

- **Publish the DI extension in CI** — the publish workflow previously packed/pushed only the core `BaseLinker` package. Adds a second `publish-nuget` step for `BaseLinker.Extensions.DependencyInjection` so it ships alongside core on each `master` push (version-change detection via the same `<PackageVersion>` regex).
- **Lockstep versioning** — bump the DI package `0.3.0 → 1.0.0` to match the core package (it's a thin companion with no independent API surface; avoids a "0.3.0 depends on 1.0.0" mismatch).
- **Metadata fix** — DI package `Description` `BaseLinker.com → Base.com` (consistent with the core package).

Verified locally: a clean Release build generates `BaseLinker.Extensions.DependencyInjection.1.0.0.nupkg` via `GeneratePackageOnBuild`. On merge, the core step will no-op (1.0.0 already published) and the DI step will publish 1.0.0.
