### PR TITLE
Revert README header icon to 57x57

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://base.com/assets/images/favicons/base.com/apple-touch-icon-120x120.png)
+![](https://base.com/assets/images/favicons/base.com/apple-touch-icon-57x57.png)
 
 # Base.com API client for .NET
 [![NuGet](https://img.shields.io/nuget/v/BaseLinker)](https://www.nuget.org/packages/BaseLinker/)


### PR DESCRIPTION
Restores the smaller 57x57 README header image (the 120x120 rendered too large inline). NuGet package icon stays 120x120. README-only — publish steps will no-op (no version change).